### PR TITLE
Create better error messaging when indices haven't been created yet

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -52,9 +52,12 @@ class CoreCrudClient(BaseCoreClient):
     def all_collections(self, **kwargs) -> Collections:
         """Read all collections from the database."""
         base_url = str(kwargs["request"].base_url)
-        collections = self.client.search(
-            index="stac_collections", doc_type="_doc", query={"match_all": {}}
-        )
+        try:
+            collections = self.client.search(
+                index="stac_collections", doc_type="_doc", query={"match_all": {}}
+            )
+        except elasticsearch.exceptions.NotFoundError:
+            raise NotFoundError(f"No collections exist in the database yet")
         serialized_collections = [
             self.collection_serializer.db_to_stac(
                 collection["_source"], base_url=base_url

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -57,7 +57,7 @@ class CoreCrudClient(BaseCoreClient):
                 index="stac_collections", doc_type="_doc", query={"match_all": {}}
             )
         except elasticsearch.exceptions.NotFoundError:
-            raise NotFoundError(f"No collections exist in the database yet")
+            raise NotFoundError("No collections exist in the database yet")
         serialized_collections = [
             self.collection_serializer.db_to_stac(
                 collection["_source"], base_url=base_url
@@ -111,7 +111,7 @@ class CoreCrudClient(BaseCoreClient):
         try:
             count = search.count()
         except elasticsearch.exceptions.NotFoundError:
-            raise NotFoundError(f"No items exist for this collection yet")
+            raise NotFoundError("No items exist for this collection yet")
         # search = search.sort({"id.keyword" : {"order" : "asc"}})
         search = search.query()[0:limit]
         collection_children = search.execute().to_dict()
@@ -142,7 +142,9 @@ class CoreCrudClient(BaseCoreClient):
         try:
             item = self.client.get(index="stac_items", id=item_id)
         except elasticsearch.exceptions.NotFoundError:
-            raise NotFoundError(f"Item {item_id} does not exist in Collection {collection_id}")
+            raise NotFoundError(
+                f"Item {item_id} does not exist in Collection {collection_id}"
+            )
         return self.item_serializer.db_to_stac(item["_source"], base_url)
 
     def _return_date(self, datetime):

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -57,7 +57,7 @@ class CoreCrudClient(BaseCoreClient):
                 index="stac_collections", doc_type="_doc", query={"match_all": {}}
             )
         except elasticsearch.exceptions.NotFoundError:
-            raise NotFoundError("No collections exist in the database yet")
+            raise NotFoundError("No collections exist")
         serialized_collections = [
             self.collection_serializer.db_to_stac(
                 collection["_source"], base_url=base_url
@@ -111,7 +111,7 @@ class CoreCrudClient(BaseCoreClient):
         try:
             count = search.count()
         except elasticsearch.exceptions.NotFoundError:
-            raise NotFoundError("No items exist for this collection yet")
+            raise NotFoundError("No items exist")
         # search = search.sort({"id.keyword" : {"order" : "asc"}})
         search = search.query()[0:limit]
         collection_children = search.execute().to_dict()
@@ -325,7 +325,7 @@ class CoreCrudClient(BaseCoreClient):
         try:
             count = search.count()
         except elasticsearch.exceptions.NotFoundError:
-            raise NotFoundError("No items have been added to the database yet")
+            raise NotFoundError("No items exist")
 
         # search = search.sort({"id.keyword" : {"order" : "asc"}})
         search = search.query()[0 : search_request.limit]

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -320,7 +320,11 @@ class CoreCrudClient(BaseCoreClient):
                 field = sort.field + ".keyword"
                 search = search.sort({field: {"order": sort.direction}})
 
-        count = search.count()
+        try:
+            count = search.count()
+        except elasticsearch.exceptions.NotFoundError:
+            raise NotFoundError("No items have been added to the database yet")
+
         # search = search.sort({"id.keyword" : {"order" : "asc"}})
         search = search.query()[0 : search_request.limit]
         response = search.execute().to_dict()


### PR DESCRIPTION
**Related Issue(s):**

- #28

**Description:**
Bypass elasticsearch error messaging when indices aren't created which is confusing

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md), if applicable