### PR TITLE
refactor tests to not need sleep, use fixture for setup/teardown

### DIFF
--- a/stac_fastapi/elasticsearch/pytest.ini
+++ b/stac_fastapi/elasticsearch/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 addopts = -sv
+asyncio_mode = auto

--- a/stac_fastapi/elasticsearch/setup.py
+++ b/stac_fastapi/elasticsearch/setup.py
@@ -29,6 +29,7 @@ extra_reqs = {
         "requests",
         "ciso8601",
         "overrides",
+        "starlette",
     ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
     "server": ["uvicorn[standard]>=0.12.0,<0.14.0"],

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/indexes.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/indexes.py
@@ -105,11 +105,11 @@ class IndexesClient:
         """Create the index for Items and Collections."""
         self.client.indices.create(
             index=ITEMS_INDEX,
-            body={"mappings": self.ES_ITEMS_MAPPINGS},
+            mappings=self.ES_ITEMS_MAPPINGS,
             ignore=400,  # ignore 400 already exists code
         )
         self.client.indices.create(
             index=COLLECTIONS_INDEX,
-            body={"mappings": self.ES_COLLECTIONS_MAPPINGS},
+            mappings=self.ES_COLLECTIONS_MAPPINGS,
             ignore=400,  # ignore 400 already exists code
         )

--- a/stac_fastapi/elasticsearch/tests/api/test_api.py
+++ b/stac_fastapi/elasticsearch/tests/api/test_api.py
@@ -1,9 +1,8 @@
-import time
 from datetime import datetime, timedelta
 
 import pytest
 
-from ..conftest import MockStarletteRequest
+from ..conftest import MockStarletteRequest, create_collection, create_item
 
 STAC_CORE_ROUTES = [
     "GET /",
@@ -66,20 +65,17 @@ def test_transactions_router(api_client):
 
 
 @pytest.mark.skip(reason="unknown")
-def test_app_transaction_extension(app_client, load_test_data, es_transactions):
+def test_app_transaction_extension(app_client, load_test_data, es_txn_client):
     item = load_test_data("test_item.json")
     resp = app_client.post(f"/collections/{item['collection']}/items", json=item)
     assert resp.status_code == 200
-    time.sleep(1)
-    es_transactions.delete_item(
+
+    es_txn_client.delete_item(
         item["id"], item["collection"], request=MockStarletteRequest
     )
 
 
-def test_app_search_response(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-
+def test_app_search_response(app_client, ctx):
     resp = app_client.get("/search", params={"ids": ["test-item"]})
     assert resp.status_code == 200
     resp_json = resp.json()
@@ -89,32 +85,29 @@ def test_app_search_response(load_test_data, app_client, es_transactions):
     assert resp_json.get("stac_version") is None
     assert resp_json.get("stac_extensions") is None
 
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
+
+def test_app_context_extension(app_client, ctx, es_txn_client):
+    test_item = ctx.item
+    test_item["id"] = "test-item-2"
+    test_item["collection"] = "test-collection-2"
+    test_collection = ctx.collection
+    test_collection["id"] = "test-collection-2"
+
+    create_collection(es_txn_client, test_collection)
+    create_item(es_txn_client, test_item)
+
+    resp = app_client.get(
+        f"/collections/{test_collection['id']}/items/{test_item['id']}"
     )
-
-
-def test_app_context_extension(load_test_data, app_client, es_transactions, es_core):
-    item = load_test_data("test_item.json")
-    collection = load_test_data("test_collection.json")
-    item["id"] = "test-item-2"
-    collection["id"] = "test-collection-2"
-    item["collection"] = collection["id"]
-    es_transactions.create_collection(collection, request=MockStarletteRequest)
-    es_transactions.create_item(item, request=MockStarletteRequest)
-
-    time.sleep(1)
-
-    resp = app_client.get(f"/collections/{collection['id']}/items/{item['id']}")
     assert resp.status_code == 200
     resp_json = resp.json()
-    assert resp_json["id"] == item["id"]
-    assert resp_json["collection"] == item["collection"]
+    assert resp_json["id"] == test_item["id"]
+    assert resp_json["collection"] == test_item["collection"]
 
-    resp = app_client.get(f"/collections/{collection['id']}")
+    resp = app_client.get(f"/collections/{test_collection['id']}")
     assert resp.status_code == 200
     resp_json = resp.json()
-    assert resp_json["id"] == collection["id"]
+    assert resp_json["id"] == test_collection["id"]
 
     resp = app_client.post("/search", json={"collections": ["test-collection-2"]})
     assert resp.status_code == 200
@@ -123,120 +116,69 @@ def test_app_context_extension(load_test_data, app_client, es_transactions, es_c
     assert "context" in resp_json
     assert resp_json["context"]["returned"] == resp_json["context"]["matched"] == 1
 
-    es_transactions.delete_collection(collection["id"], request=MockStarletteRequest)
-    es_transactions.delete_item(
-        item["id"], collection["id"], request=MockStarletteRequest
-    )
-
 
 @pytest.mark.skip(reason="fields not implemented yet")
-def test_app_fields_extension(load_test_data, app_client, es_transactions):
+def test_app_fields_extension(load_test_data, app_client, es_txn_client):
     item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
+    es_txn_client.create_item(item, request=MockStarletteRequest, refresh=True)
 
     resp = app_client.get("/search", params={"collections": ["test-collection"]})
     assert resp.status_code == 200
     resp_json = resp.json()
     assert list(resp_json["features"][0]["properties"]) == ["datetime"]
 
-    es_transactions.delete_item(
+    es_txn_client.delete_item(
         item["id"], item["collection"], request=MockStarletteRequest
     )
 
 
-def test_app_query_extension_gt(load_test_data, app_client, es_transactions):
-    test_item = load_test_data("test_item.json")
-    es_transactions.create_item(test_item, request=MockStarletteRequest)
-
-    params = {"query": {"proj:epsg": {"gt": test_item["properties"]["proj:epsg"]}}}
+def test_app_query_extension_gt(app_client, ctx):
+    params = {"query": {"proj:epsg": {"gt": ctx.item["properties"]["proj:epsg"]}}}
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 200
     resp_json = resp.json()
     assert len(resp_json["features"]) == 0
 
-    # es_transactions.delete_collection(collection["id"], request=MockStarletteRequest)
-    es_transactions.delete_item(
-        test_item["id"], test_item["collection"], request=MockStarletteRequest
-    )
 
-
-def test_app_query_extension_gte(load_test_data, app_client, es_transactions):
-    test_item = load_test_data("test_item.json")
-    es_transactions.create_item(test_item, request=MockStarletteRequest)
-    time.sleep(1)
-    params = {"query": {"proj:epsg": {"gte": test_item["properties"]["proj:epsg"]}}}
+def test_app_query_extension_gte(app_client, ctx):
+    params = {"query": {"proj:epsg": {"gte": ctx.item["properties"]["proj:epsg"]}}}
     resp = app_client.post("/search", json=params)
+
     assert resp.status_code == 200
-    resp_json = resp.json()
-    assert len(resp_json["features"]) == 1
-
-    es_transactions.delete_item(
-        test_item["id"], test_item["collection"], request=MockStarletteRequest
-    )
+    assert len(resp.json()["features"]) == 1
 
 
-def test_app_query_extension_limit_lt0(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-
-    params = {"limit": -1}
-    resp = app_client.post("/search", json=params)
-    assert resp.status_code == 400
-
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
-    )
+def test_app_query_extension_limit_lt0(app_client, ctx):
+    assert app_client.post("/search", json={"limit": -1}).status_code == 400
 
 
-def test_app_query_extension_limit_gt10000(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-
-    params = {"limit": 10001}
-    resp = app_client.post("/search", json=params)
-    assert resp.status_code == 400
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
-    )
+def test_app_query_extension_limit_gt10000(app_client, ctx):
+    assert app_client.post("/search", json={"limit": 10001}).status_code == 400
 
 
-def test_app_query_extension_limit_10000(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-
+def test_app_query_extension_limit_10000(app_client, ctx):
     params = {"limit": 10000}
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 200
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
-    )
 
 
-@pytest.mark.skip(
-    reason="No mapping found for [properties__datetime.keyword] in order to sort on"
-)
-def test_app_sort_extension(load_test_data, app_client, es_transactions):
-    first_item = load_test_data("test_item.json")
+def test_app_sort_extension(app_client, es_txn_client, ctx):
+    first_item = ctx.item
     item_date = datetime.strptime(
         first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
     )
-    es_transactions.create_item(first_item, request=MockStarletteRequest)
 
-    time.sleep(1)
-
-    second_item = load_test_data("test_item.json")
+    second_item = dict(first_item)
     second_item["id"] = "another-item"
     another_item_date = item_date - timedelta(days=1)
     second_item["properties"]["datetime"] = another_item_date.strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
-    es_transactions.create_item(second_item, request=MockStarletteRequest)
-
-    time.sleep(1)
+    create_item(es_txn_client, second_item)
 
     params = {
         "collections": [first_item["collection"]],
-        "sortby": [{"field": "datetime", "direction": "desc"}],
+        "sortby": [{"field": "properties.datetime", "direction": "desc"}],
     }
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 200
@@ -244,42 +186,24 @@ def test_app_sort_extension(load_test_data, app_client, es_transactions):
     assert resp_json["features"][0]["id"] == first_item["id"]
     assert resp_json["features"][1]["id"] == second_item["id"]
 
-    es_transactions.delete_item(
-        first_item["id"], first_item["collection"], request=MockStarletteRequest
-    )
-    es_transactions.delete_item(
-        second_item["id"], second_item["collection"], request=MockStarletteRequest
-    )
 
-
-def test_search_invalid_date(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-
+def test_search_invalid_date(app_client, ctx):
     params = {
         "datetime": "2020-XX-01/2020-10-30",
-        "collections": [item["collection"]],
+        "collections": [ctx.item["collection"]],
     }
 
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 400
 
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
-    )
 
-
-def test_search_point_intersects(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-
-    time.sleep(2)
+def test_search_point_intersects(app_client, ctx):
     point = [150.04, -33.14]
     intersects = {"type": "Point", "coordinates": point}
 
     params = {
         "intersects": intersects,
-        "collections": [item["collection"]],
+        "collections": [ctx.item["collection"]],
     }
     resp = app_client.post("/search", json=params)
 
@@ -287,74 +211,51 @@ def test_search_point_intersects(load_test_data, app_client, es_transactions):
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1
 
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
-    )
 
-
-def test_datetime_non_interval(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-    time.sleep(2)
-    alternate_formats = [
+def test_datetime_non_interval(app_client, ctx):
+    dt_formats = [
         "2020-02-12T12:30:22+00:00",
         "2020-02-12T12:30:22.00Z",
         "2020-02-12T12:30:22Z",
         "2020-02-12T12:30:22.00+00:00",
     ]
-    for date in alternate_formats:
+
+    for dt in dt_formats:
         params = {
-            "datetime": date,
-            "collections": [item["collection"]],
+            "datetime": ctx.item["properties"]["datetime"],
+            "collections": [ctx.item["collection"]],
         }
 
         resp = app_client.post("/search", json=params)
         assert resp.status_code == 200
         resp_json = resp.json()
-        # datetime is returned in this format "2020-02-12T12:30:22+00:00"
-        assert resp_json["features"][0]["properties"]["datetime"][0:19] == date[0:19]
-
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
-    )
+        # datetime is returned in this format "2020-02-12T12:30:22Z"
+        assert resp_json["features"][0]["properties"]["datetime"][0:19] == dt[0:19]
 
 
-def test_bbox_3d(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-    time.sleep(1)
-
+def test_bbox_3d(app_client, ctx):
     australia_bbox = [106.343365, -47.199523, 0.1, 168.218365, -19.437288, 0.1]
     params = {
         "bbox": australia_bbox,
-        "collections": [item["collection"]],
+        "collections": [ctx.item["collection"]],
     }
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 200
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
-    )
 
 
-def test_search_line_string_intersects(load_test_data, app_client, es_transactions):
-    item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
-    time.sleep(2)
-
+def test_search_line_string_intersects(app_client, ctx):
     line = [[150.04, -33.14], [150.22, -33.89]]
     intersects = {"type": "LineString", "coordinates": line}
-
     params = {
         "intersects": intersects,
-        "collections": [item["collection"]],
+        "collections": [ctx.item["collection"]],
     }
+
     resp = app_client.post("/search", json=params)
+
     assert resp.status_code == 200
+
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1
-
-    es_transactions.delete_item(
-        item["id"], item["collection"], request=MockStarletteRequest
-    )

--- a/stac_fastapi/elasticsearch/tests/api/test_api.py
+++ b/stac_fastapi/elasticsearch/tests/api/test_api.py
@@ -222,7 +222,7 @@ def test_datetime_non_interval(app_client, ctx):
 
     for dt in dt_formats:
         params = {
-            "datetime": ctx.item["properties"]["datetime"],
+            "datetime": dt,
             "collections": [ctx.item["collection"]],
         }
 

--- a/stac_fastapi/elasticsearch/tests/clients/test_elasticsearch.py
+++ b/stac_fastapi/elasticsearch/tests/clients/test_elasticsearch.py
@@ -1,81 +1,75 @@
-import time
 import uuid
 from copy import deepcopy
 from typing import Callable
 
 import pytest
 from stac_pydantic import Item
-from tests.conftest import MockStarletteRequest
 
 from stac_fastapi.api.app import StacApi
-from stac_fastapi.elasticsearch.core import (
-    BulkTransactionsClient,
-    CoreCrudClient,
-    TransactionsClient,
-)
+from stac_fastapi.elasticsearch.core import BulkTransactionsClient, CoreCrudClient
 from stac_fastapi.extensions.third_party.bulk_transactions import Items
 from stac_fastapi.types.errors import ConflictError, NotFoundError
+
+from ..conftest import MockStarletteRequest, create_item
 
 
 def test_create_collection(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     data = load_test_data("test_collection.json")
     try:
-        es_transactions.create_collection(data, request=MockStarletteRequest)
+        es_txn_client.create_collection(data, request=MockStarletteRequest)
     except Exception:
         pass
     coll = es_core.get_collection(data["id"], request=MockStarletteRequest)
     assert coll["id"] == data["id"]
-    es_transactions.delete_collection(data["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(data["id"], request=MockStarletteRequest)
 
 
 def test_create_collection_already_exists(
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     data = load_test_data("test_collection.json")
-    es_transactions.create_collection(data, request=MockStarletteRequest)
-
-    time.sleep(1)
+    es_txn_client.create_collection(data, request=MockStarletteRequest)
 
     # change id to avoid elasticsearch duplicate key error
     data["_id"] = str(uuid.uuid4())
 
     with pytest.raises(ConflictError):
-        es_transactions.create_collection(data, request=MockStarletteRequest)
+        es_txn_client.create_collection(data, request=MockStarletteRequest)
 
-    es_transactions.delete_collection(data["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(data["id"], request=MockStarletteRequest)
 
 
 def test_update_collection(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     data = load_test_data("test_collection.json")
 
-    es_transactions.create_collection(data, request=MockStarletteRequest)
+    es_txn_client.create_collection(data, request=MockStarletteRequest)
     data["keywords"].append("new keyword")
-    es_transactions.update_collection(data, request=MockStarletteRequest)
+    es_txn_client.update_collection(data, request=MockStarletteRequest)
 
     coll = es_core.get_collection(data["id"], request=MockStarletteRequest)
     assert "new keyword" in coll["keywords"]
 
-    es_transactions.delete_collection(data["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(data["id"], request=MockStarletteRequest)
 
 
 def test_delete_collection(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     data = load_test_data("test_collection.json")
-    es_transactions.create_collection(data, request=MockStarletteRequest)
+    es_txn_client.create_collection(data, request=MockStarletteRequest)
 
-    es_transactions.delete_collection(data["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(data["id"], request=MockStarletteRequest)
 
     with pytest.raises(NotFoundError):
         es_core.get_collection(data["id"], request=MockStarletteRequest)
@@ -83,26 +77,26 @@ def test_delete_collection(
 
 def test_get_collection(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     data = load_test_data("test_collection.json")
-    es_transactions.create_collection(data, request=MockStarletteRequest)
+    es_txn_client.create_collection(data, request=MockStarletteRequest)
     coll = es_core.get_collection(data["id"], request=MockStarletteRequest)
     assert coll["id"] == data["id"]
 
-    es_transactions.delete_collection(data["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(data["id"], request=MockStarletteRequest)
 
 
 def test_get_item(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     collection_data = load_test_data("test_collection.json")
     item_data = load_test_data("test_item.json")
-    es_transactions.create_collection(collection_data, request=MockStarletteRequest)
-    es_transactions.create_item(item_data, request=MockStarletteRequest)
+    es_txn_client.create_collection(collection_data, request=MockStarletteRequest)
+    es_txn_client.create_item(item_data, request=MockStarletteRequest)
     got_item = es_core.get_item(
         item_id=item_data["id"],
         collection_id=item_data["collection"],
@@ -111,29 +105,25 @@ def test_get_item(
     assert got_item["id"] == item_data["id"]
     assert got_item["collection"] == item_data["collection"]
 
-    es_transactions.delete_collection(
-        collection_data["id"], request=MockStarletteRequest
-    )
-    es_transactions.delete_item(
+    es_txn_client.delete_collection(collection_data["id"], request=MockStarletteRequest)
+    es_txn_client.delete_item(
         item_data["id"], item_data["collection"], request=MockStarletteRequest
     )
 
 
 def test_get_collection_items(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     coll = load_test_data("test_collection.json")
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
+    es_txn_client.create_collection(coll, request=MockStarletteRequest)
 
     item = load_test_data("test_item.json")
 
     for _ in range(5):
         item["id"] = str(uuid.uuid4())
-        es_transactions.create_item(item, request=MockStarletteRequest)
-
-    time.sleep(2)
+        es_txn_client.create_item(item, request=MockStarletteRequest, refresh=True)
 
     fc = es_core.item_collection(coll["id"], request=MockStarletteRequest)
     assert len(fc["features"]) == 5
@@ -141,22 +131,20 @@ def test_get_collection_items(
     for item in fc["features"]:
         assert item["collection"] == coll["id"]
 
-    es_transactions.delete_collection(coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(coll["id"], request=MockStarletteRequest)
     for item in fc["features"]:
-        es_transactions.delete_item(
-            item["id"], coll["id"], request=MockStarletteRequest
-        )
+        es_txn_client.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
 
 
 def test_create_item(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     coll = load_test_data("test_collection.json")
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
+    es_txn_client.create_collection(coll, request=MockStarletteRequest)
     item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
+    es_txn_client.create_item(item, request=MockStarletteRequest, refresh=True)
     resp = es_core.get_item(
         item["id"], item["collection"], request=MockStarletteRequest
     )
@@ -164,60 +152,60 @@ def test_create_item(
         exclude={"links": ..., "properties": {"created", "updated"}}
     ) == Item(**resp).dict(exclude={"links": ..., "properties": {"created", "updated"}})
 
-    es_transactions.delete_collection(coll["id"], request=MockStarletteRequest)
-    es_transactions.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
 
 
 def test_create_item_already_exists(
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     coll = load_test_data("test_collection.json")
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
+    es_txn_client.create_collection(coll, request=MockStarletteRequest)
 
     item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
+    es_txn_client.create_item(item, request=MockStarletteRequest, refresh=True)
 
     with pytest.raises(ConflictError):
-        es_transactions.create_item(item, request=MockStarletteRequest)
+        es_txn_client.create_item(item, request=MockStarletteRequest, refresh=True)
 
-    es_transactions.delete_collection(coll["id"], request=MockStarletteRequest)
-    es_transactions.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
 
 
 def test_update_item(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     coll = load_test_data("test_collection.json")
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
+    es_txn_client.create_collection(coll, request=MockStarletteRequest)
 
     item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
+    es_txn_client.create_item(item, request=MockStarletteRequest, refresh=True)
 
     item["properties"]["foo"] = "bar"
-    es_transactions.update_item(item, request=MockStarletteRequest)
+    es_txn_client.update_item(item, request=MockStarletteRequest)
 
     updated_item = es_core.get_item(
         item["id"], item["collection"], request=MockStarletteRequest
     )
     assert updated_item["properties"]["foo"] == "bar"
 
-    es_transactions.delete_collection(coll["id"], request=MockStarletteRequest)
-    es_transactions.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
 
 
 def test_update_geometry(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     coll = load_test_data("test_collection.json")
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
+    es_txn_client.create_collection(coll, request=MockStarletteRequest)
 
     item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
+    es_txn_client.create_item(item, request=MockStarletteRequest, refresh=True)
 
     new_coordinates = [
         [
@@ -230,33 +218,33 @@ def test_update_geometry(
     ]
 
     item["geometry"]["coordinates"] = new_coordinates
-    es_transactions.update_item(item, request=MockStarletteRequest)
+    es_txn_client.update_item(item, request=MockStarletteRequest)
 
     updated_item = es_core.get_item(
         item["id"], item["collection"], request=MockStarletteRequest
     )
     assert updated_item["geometry"]["coordinates"] == new_coordinates
 
-    es_transactions.delete_collection(coll["id"], request=MockStarletteRequest)
-    es_transactions.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_item(item["id"], coll["id"], request=MockStarletteRequest)
 
 
 def test_delete_item(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
 ):
     coll = load_test_data("test_collection.json")
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
+    es_txn_client.create_collection(coll, request=MockStarletteRequest)
 
     item = load_test_data("test_item.json")
-    es_transactions.create_item(item, request=MockStarletteRequest)
+    es_txn_client.create_item(item, request=MockStarletteRequest, refresh=True)
 
-    es_transactions.delete_item(
+    es_txn_client.delete_item(
         item["id"], item["collection"], request=MockStarletteRequest
     )
 
-    es_transactions.delete_collection(coll["id"], request=MockStarletteRequest)
+    es_txn_client.delete_collection(coll["id"], request=MockStarletteRequest)
 
     with pytest.raises(NotFoundError):
         es_core.get_item(item["id"], item["collection"], request=MockStarletteRequest)
@@ -264,12 +252,12 @@ def test_delete_item(
 
 def test_bulk_item_insert(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     es_bulk_transactions: BulkTransactionsClient,
     load_test_data: Callable,
 ):
     coll = load_test_data("test_collection.json")
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
+    es_txn_client.create_collection(coll, request=MockStarletteRequest)
 
     item = load_test_data("test_item.json")
 
@@ -282,8 +270,8 @@ def test_bulk_item_insert(
     # fc = es_core.item_collection(coll["id"], request=MockStarletteRequest)
     # assert len(fc["features"]) == 0
 
-    es_bulk_transactions.bulk_item_insert(Items(items=items))
-    time.sleep(3)
+    es_bulk_transactions.bulk_item_insert(Items(items=items), refresh=True)
+
     fc = es_core.item_collection(coll["id"], request=MockStarletteRequest)
     assert len(fc["features"]) >= 10
 
@@ -295,32 +283,29 @@ def test_bulk_item_insert(
 
 def test_feature_collection_insert(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     es_bulk_transactions: BulkTransactionsClient,
-    load_test_data: Callable,
+    test_item,
+    test_collection,
+    ctx,
 ):
-    coll = load_test_data("test_collection.json")
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
-
-    item = load_test_data("test_item.json")
-
     features = []
     for _ in range(10):
-        _item = deepcopy(item)
+        _item = deepcopy(test_item)
         _item["id"] = str(uuid.uuid4())
         features.append(_item)
 
     feature_collection = {"type": "FeatureCollection", "features": features}
 
-    es_transactions.create_item(feature_collection, request=MockStarletteRequest)
-    time.sleep(3)
-    fc = es_core.item_collection(coll["id"], request=MockStarletteRequest)
+    create_item(es_txn_client, feature_collection)
+
+    fc = es_core.item_collection(test_collection["id"], request=MockStarletteRequest)
     assert len(fc["features"]) >= 10
 
 
 def test_landing_page_no_collection_title(
     es_core: CoreCrudClient,
-    es_transactions: TransactionsClient,
+    es_txn_client,
     load_test_data: Callable,
     api_client: StacApi,
 ):
@@ -329,7 +314,7 @@ def test_landing_page_no_collection_title(
 
     coll = load_test_data("test_collection.json")
     del coll["title"]
-    es_transactions.create_collection(coll, request=MockStarletteRequest)
+    es_txn_client.create_collection(coll, request=MockStarletteRequest)
 
     landing_page = es_core.landing_page(request=MockStarletteRequestWithApp)
     for link in landing_page["links"]:


### PR DESCRIPTION


**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/70

**Description:**

- refactor tests to not need sleep
- use fixture for setup/teardown of most tests
- remove use of execute methods in ES DSL

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the changelog