### PR TITLE
convert all uses of query to filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ For changes, see the [Changelog](CHANGELOG.md).
 To install the classes in your local Python env, run:
 
 ```shell
-cd stac_fastapi/elasticsearch
-pip install -e '.[dev]'
+pip install -e 'stac_fastapi/elasticsearch[dev]'
 ```
 
 ### Pre-commit

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -144,9 +144,7 @@ class DatabaseLogic:
                         "geometry": {
                             "shape": {
                                 "type": "polygon",
-                                "coordinates": bbox2polygon(
-                                    bbox[0], bbox[1], bbox[2], bbox[3]
-                                ),
+                                "coordinates": bbox2polygon(*bbox),
                             },
                             "relation": "intersects",
                         }


### PR DESCRIPTION
**Related Issue(s):**

- #82 

**Description:**

- Most of the searches were done using `query` rather than `filter`. The difference is that query uses scoring to rank results (more like as free-text search), whereas filter does a SQL select style restriction. Filter is faster than query and results can be cached by ES.
- fixed the count to reflect how many items where actually being returned. 
- retrieve more than 10 collections now (up to 100)
- consolidate /collections/{c_id}/items logic to use execute_search instead of mostly-duplicated code.


**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the changelog