### PR TITLE
do bulk insert using asyncio executor instead of blocking

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1,4 +1,5 @@
 """Database logic."""
+import asyncio
 import logging
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from typing import Dict, List, Optional, Tuple, Type, Union
@@ -325,9 +326,11 @@ class DatabaseLogic:
 
     async def bulk_async(self, processed_items, refresh: bool = False):
         """Database logic for async bulk item insertion."""
-        # todo: wrap as async
-        helpers.bulk(
-            self.sync_client, self._mk_actions(processed_items), refresh=refresh
+        await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: helpers.bulk(
+                self.sync_client, self._mk_actions(processed_items), refresh=refresh
+            ),
         )
 
     def bulk_sync(self, processed_items, refresh: bool = False):


### PR DESCRIPTION
**Related Issue(s):**

- #80 

**Description:**

- run the sync bulk operation in an executor so it doesn't block the main thread.

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the changelog