### PR TITLE
run count and search concurrently, but don't wait for count to be done

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1,4 +1,5 @@
 """Database logic."""
+import asyncio
 import logging
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from typing import Dict, List, Optional, Tuple, Type, Union
@@ -196,23 +197,27 @@ class DatabaseLogic:
         base_url: str,
     ) -> Tuple[List[Item], Optional[int], Optional[str]]:
         """Database logic to execute search with limit."""
-        body = search.to_dict()
-
-        maybe_count = (
-            await self.client.count(index=ITEMS_INDEX, body=search.to_dict(count=True))
-        ).get("count")
-
         search_after = None
         if token:
             search_after = urlsafe_b64decode(token.encode()).decode().split(",")
 
-        es_response = await self.client.search(
-            index=ITEMS_INDEX,
-            query=body.get("query"),
-            sort=sort or DEFAULT_SORT,
-            search_after=search_after,
-            size=limit,
+        query = search.query.to_dict() if search.query else None
+
+        search_task = asyncio.create_task(
+            self.client.search(
+                index=ITEMS_INDEX,
+                query=query,
+                sort=sort or DEFAULT_SORT,
+                search_after=search_after,
+                size=limit,
+            )
         )
+
+        count_task = asyncio.create_task(
+            self.client.count(index=ITEMS_INDEX, body=search.to_dict(count=True))
+        )
+
+        es_response = await search_task
 
         hits = es_response["hits"]["hits"]
         items = [
@@ -225,6 +230,15 @@ class DatabaseLogic:
             next_token = urlsafe_b64encode(
                 ",".join([str(x) for x in sort_array]).encode()
             ).decode()
+
+        # (1) count should not block returning results, so don't wait for it to be done
+        # (2) don't cancel the task so that it will populate the ES cache for subsequent counts
+        maybe_count = None
+        if count_task.done():
+            try:
+                maybe_count = count_task.result().get("count")
+            except Exception as e:  # type: ignore
+                logger.error(f"Count task failed: {e}")
 
         return items, maybe_count, next_token
 

--- a/stac_fastapi/elasticsearch/tests/api/test_api.py
+++ b/stac_fastapi/elasticsearch/tests/api/test_api.py
@@ -103,7 +103,9 @@ async def test_app_context_extension(app_client, ctx, txn_client):
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1
     assert "context" in resp_json
-    assert resp_json["context"]["returned"] == resp_json["context"]["matched"] == 1
+    assert resp_json["context"]["returned"] == 1
+    if matched := resp_json["context"].get("matched"):
+        assert matched == 1
 
 
 @pytest.mark.skip(reason="fields not implemented yet")

--- a/stac_fastapi/elasticsearch/tests/resources/test_item.py
+++ b/stac_fastapi/elasticsearch/tests/resources/test_item.py
@@ -184,7 +184,8 @@ async def test_get_item_collection(app_client, ctx, txn_client):
     assert resp.status_code == 200
 
     item_collection = resp.json()
-    assert item_collection["context"]["matched"] == item_count + 1
+    if matched := item_collection["context"].get("matched"):
+        assert matched == item_count + 1
 
 
 @pytest.mark.skip(reason="Pagination extension not implemented")


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/76

**Description:**

Previously, the count and search ES requests were run sequentially, so every search request was delayed for as long as it took to get the complete count of matches.  This is an optional field in the Context Extension, and is generally not worth waiting on. 

Now, the code creates tasks for both the count and search, and only awaits the search task. If the count task isn't completed by the time the search is finished and its results serialized to Items, the count is ignored and the items. are returned.

Also note that we do not cancel the count task, so that it will complete and the ES cache will be populated with the results for the next similar query.

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the changelog