### PR TITLE
remove fields extension advertisement, as this is not supported

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -10,9 +10,8 @@ from stac_fastapi.elasticsearch.core import (
 from stac_fastapi.elasticsearch.extensions import QueryExtension
 from stac_fastapi.elasticsearch.indexes import IndexesClient
 from stac_fastapi.elasticsearch.session import Session
-from stac_fastapi.extensions.core import (
+from stac_fastapi.extensions.core import (  # FieldsExtension,
     ContextExtension,
-    FieldsExtension,
     SortExtension,
     TokenPaginationExtension,
     TransactionExtension,
@@ -25,7 +24,7 @@ session = Session.create_from_settings(settings)
 extensions = [
     TransactionExtension(client=TransactionsClient(session=session), settings=settings),
     BulkTransactionExtension(client=BulkTransactionsClient(session=session)),
-    FieldsExtension(),
+    # FieldsExtension(),
     QueryExtension(),
     SortExtension(),
     TokenPaginationExtension(),

--- a/stac_fastapi/elasticsearch/tests/conftest.py
+++ b/stac_fastapi/elasticsearch/tests/conftest.py
@@ -19,9 +19,8 @@ from stac_fastapi.elasticsearch.core import (
 from stac_fastapi.elasticsearch.database_logic import COLLECTIONS_INDEX, ITEMS_INDEX
 from stac_fastapi.elasticsearch.extensions import QueryExtension
 from stac_fastapi.elasticsearch.indexes import IndexesClient
-from stac_fastapi.extensions.core import (
+from stac_fastapi.extensions.core import (  # FieldsExtension,
     ContextExtension,
-    FieldsExtension,
     SortExtension,
     TokenPaginationExtension,
     TransactionExtension,
@@ -152,7 +151,7 @@ async def app():
         ),
         ContextExtension(),
         SortExtension(),
-        FieldsExtension(),
+        # FieldsExtension(),
         QueryExtension(),
         TokenPaginationExtension(),
     ]


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/89

**Description:**

- fields conformance class is advertised, but the behavior is not supported.

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the changelog