### PR TITLE
Move db to stac serializer to core.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Elasticsearch index mappings updated to be more thorough.
 - Endpoints that return items (e.g., /search) now sort the results by 'properties.datetime,id,collection'.
   Previously, there was no sort order defined.
+- Db_to_stac serializer moved to core.py for consistency as it existed in both core and database_logic previously. 
+- Use genexp in execute_search and get_all_collections to return results.
+- Added db_to_stac serializer to item_collection method in core.py.
 
 ### Removed
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -52,7 +52,11 @@ class CoreClient(AsyncBaseCoreClient):
     async def all_collections(self, **kwargs) -> Collections:
         """Read all collections from the database."""
         base_url = str(kwargs["request"].base_url)
-        collection_list = await self.database.get_all_collections(base_url=base_url)
+        collection_list = await self.database.get_all_collections()
+        collection_list =  [
+            self.collection_serializer.db_to_stac(c, base_url=base_url)
+            for c in collection_list
+        ]
 
         links = [
             {

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -91,6 +91,7 @@ class CoreClient(AsyncBaseCoreClient):
     ) -> ItemCollection:
         """Read an item collection from the database."""
         request: Request = kwargs["request"]
+        base_url = str(kwargs["request"].base_url)
 
         items, maybe_count, next_token = await self.database.execute_search(
             search=self.database.apply_collections_filter(
@@ -100,6 +101,10 @@ class CoreClient(AsyncBaseCoreClient):
             token=token,
             sort=None,
         )
+
+        items = [
+            self.item_serializer.db_to_stac(item, base_url=base_url) for item in items
+        ]
 
         context_obj = None
         if self.extension_is_enabled("ContextExtension"):

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -272,6 +272,11 @@ class CoreClient(AsyncBaseCoreClient):
             base_url=base_url,
         )
 
+        items = [
+            self.item_serializer.db_to_stac(item, base_url=base_url)
+            for item in items
+        ]
+
         # if self.extension_is_enabled("FieldsExtension"):
         #     if search_request.query is not None:
         #         query_include: Set[str] = set(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -53,7 +53,7 @@ class CoreClient(AsyncBaseCoreClient):
         """Read all collections from the database."""
         base_url = str(kwargs["request"].base_url)
         collection_list = await self.database.get_all_collections()
-        collection_list =  [
+        collection_list = [
             self.collection_serializer.db_to_stac(c, base_url=base_url)
             for c in collection_list
         ]
@@ -91,7 +91,6 @@ class CoreClient(AsyncBaseCoreClient):
     ) -> ItemCollection:
         """Read an item collection from the database."""
         request: Request = kwargs["request"]
-        base_url = str(request.base_url)
 
         items, maybe_count, next_token = await self.database.execute_search(
             search=self.database.apply_collections_filter(
@@ -100,7 +99,6 @@ class CoreClient(AsyncBaseCoreClient):
             limit=limit,
             token=token,
             sort=None,
-            base_url=base_url,
         )
 
         context_obj = None
@@ -273,12 +271,10 @@ class CoreClient(AsyncBaseCoreClient):
             limit=limit,
             token=search_request.token,  # type: ignore
             sort=sort,
-            base_url=base_url,
         )
 
         items = [
-            self.item_serializer.db_to_stac(item, base_url=base_url)
-            for item in items
+            self.item_serializer.db_to_stac(item, base_url=base_url) for item in items
         ]
 
         # if self.extension_is_enabled("FieldsExtension"):

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -71,9 +71,7 @@ class DatabaseLogic:
         # https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/65
         # collections should be paginated, but at least return more than the default 10 for now
         collections = await self.client.search(index=COLLECTIONS_INDEX, size=1000)
-        return [
-            c["_source"] for c in collections["hits"]["hits"]
-        ]
+        return [c["_source"] for c in collections["hits"]["hits"]]
 
     async def get_one_item(self, collection_id: str, item_id: str) -> Dict:
         """Database logic to retrieve a single item."""
@@ -192,7 +190,6 @@ class DatabaseLogic:
         limit: int,
         token: Optional[str],
         sort: Optional[Dict[str, Dict[str, str]]],
-        base_url: str,
     ) -> Tuple[List[Item], Optional[int], Optional[str]]:
         """Database logic to execute search with limit."""
         search_after = None
@@ -218,9 +215,7 @@ class DatabaseLogic:
         es_response = await search_task
 
         hits = es_response["hits"]["hits"]
-        items = [
-            hit["_source"] for hit in hits
-        ]
+        items = [hit["_source"] for hit in hits]
 
         next_token = None
         if hits and (sort_array := hits[-1].get("sort")):

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -66,15 +66,13 @@ class DatabaseLogic:
 
     """CORE LOGIC"""
 
-    async def get_all_collections(self, base_url: str) -> List[Collection]:
+    async def get_all_collections(self) -> List[Collection]:
         """Database logic to retrieve a list of all collections."""
         # https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/65
         # collections should be paginated, but at least return more than the default 10 for now
         collections = await self.client.search(index=COLLECTIONS_INDEX, size=1000)
-
         return [
-            self.collection_serializer.db_to_stac(c["_source"], base_url=base_url)
-            for c in collections["hits"]["hits"]
+            c["_source"] for c in collections["hits"]["hits"]
         ]
 
     async def get_one_item(self, collection_id: str, item_id: str) -> Dict:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 from base64 import urlsafe_b64decode, urlsafe_b64encode
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, Union, Any, Iterable
 
 import attr
 import elasticsearch
@@ -66,12 +66,12 @@ class DatabaseLogic:
 
     """CORE LOGIC"""
 
-    async def get_all_collections(self) -> List[Collection]:
+    async def get_all_collections(self) -> List[Dict[str, Any]]:
         """Database logic to retrieve a list of all collections."""
         # https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/65
         # collections should be paginated, but at least return more than the default 10 for now
         collections = await self.client.search(index=COLLECTIONS_INDEX, size=1000)
-        return [c["_source"] for c in collections["hits"]["hits"]]
+        return (c["_source"] for c in collections["hits"]["hits"])
 
     async def get_one_item(self, collection_id: str, item_id: str) -> Dict:
         """Database logic to retrieve a single item."""
@@ -190,7 +190,7 @@ class DatabaseLogic:
         limit: int,
         token: Optional[str],
         sort: Optional[Dict[str, Dict[str, str]]],
-    ) -> Tuple[List[Item], Optional[int], Optional[str]]:
+    ) -> Tuple[Iterable[Dict[str, Any]], Optional[int], Optional[str]]:
         """Database logic to execute search with limit."""
         search_after = None
         if token:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -215,7 +215,7 @@ class DatabaseLogic:
         es_response = await search_task
 
         hits = es_response["hits"]["hits"]
-        items = [hit["_source"] for hit in hits]
+        items = (hit["_source"] for hit in hits)
 
         next_token = None
         if hits and (sort_array := hits[-1].get("sort")):

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -221,8 +221,7 @@ class DatabaseLogic:
 
         hits = es_response["hits"]["hits"]
         items = [
-            self.item_serializer.db_to_stac(hit["_source"], base_url=base_url)
-            for hit in hits
+            hit["_source"] for hit in hits
         ]
 
         next_token = None

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 from base64 import urlsafe_b64decode, urlsafe_b64encode
-from typing import Dict, List, Optional, Tuple, Type, Union, Any, Iterable
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import attr
 import elasticsearch


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/72

**Description:**
Moved db_to_stac serialization out of database_logic and into core.py for consistency

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the changelog