### PR TITLE
for bulk operations, don't raise an exception if any of the ingested items fails

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -497,6 +497,7 @@ class DatabaseLogic:
                 self.sync_client,
                 mk_actions(collection_id, processed_items),
                 refresh=refresh,
+                raise_on_error=False,
             ),
         )
 
@@ -508,6 +509,7 @@ class DatabaseLogic:
             self.sync_client,
             mk_actions(collection_id, processed_items),
             refresh=refresh,
+            raise_on_error=False,
         )
 
     # DANGER


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Description:**

The default behavior of the bulk api (which streams the individual operations in batches) is to immediately stop and raise an exception if any of the operations in a batch fail. Instead, don't raise on that error, and just keep ingesting the items. This is so that if there's a bad item that's being ingested, it doesn't prevent the others in the batch from being ingested. 

TBD is better reporting back to the caller as to which items succeeded and failed.


**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the changelog