### PR TITLE
advertise correct conformance class uri strings

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -1,4 +1,8 @@
 """FastAPI application."""
+from typing import List
+
+import attr
+
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
 from stac_fastapi.elasticsearch.config import ElasticsearchSettings
@@ -21,14 +25,44 @@ from stac_fastapi.extensions.third_party import BulkTransactionExtension
 settings = ElasticsearchSettings()
 session = Session.create_from_settings(settings)
 
+
+# All of these extensions have their conformance class URL
+# incorrect, with an extra `/` before the #
+@attr.s
+class FixedSortExtension(SortExtension):
+    """Fixed Sort Extension string."""
+
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search#sort"]
+    )
+
+
+@attr.s
+class FixedQueryExtension(QueryExtension):
+    """Fixed Query Extension string."""
+
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search#query"]
+    )
+
+
+@attr.s
+class FixedContextExtension(ContextExtension):
+    """Fixed Context Extension string."""
+
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search#context"]
+    )
+
+
 extensions = [
     TransactionExtension(client=TransactionsClient(session=session), settings=settings),
     BulkTransactionExtension(client=BulkTransactionsClient(session=session)),
     # FieldsExtension(),
-    QueryExtension(),
-    SortExtension(),
+    FixedQueryExtension(),
+    FixedSortExtension(),
     TokenPaginationExtension(),
-    ContextExtension(),
+    FixedContextExtension(),
 ]
 
 post_request_model = create_post_request_model(extensions)

--- a/stac_fastapi/elasticsearch/tests/conftest.py
+++ b/stac_fastapi/elasticsearch/tests/conftest.py
@@ -10,6 +10,11 @@ from httpx import AsyncClient
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_request_model
+from stac_fastapi.elasticsearch.app import (
+    FixedContextExtension,
+    FixedQueryExtension,
+    FixedSortExtension,
+)
 from stac_fastapi.elasticsearch.config import AsyncElasticsearchSettings
 from stac_fastapi.elasticsearch.core import (
     BulkTransactionsClient,
@@ -17,10 +22,7 @@ from stac_fastapi.elasticsearch.core import (
     TransactionsClient,
 )
 from stac_fastapi.elasticsearch.database_logic import create_collection_index
-from stac_fastapi.elasticsearch.extensions import QueryExtension
 from stac_fastapi.extensions.core import (  # FieldsExtension,
-    ContextExtension,
-    SortExtension,
     TokenPaginationExtension,
     TransactionExtension,
 )
@@ -143,10 +145,10 @@ async def app():
         TransactionExtension(
             client=TransactionsClient(session=None), settings=settings
         ),
-        ContextExtension(),
-        SortExtension(),
+        FixedContextExtension(),
+        FixedSortExtension(),
         # FieldsExtension(),
-        QueryExtension(),
+        FixedQueryExtension(),
         TokenPaginationExtension(),
     ]
 


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Description:**

Fix incorrect conformance class URIs (already fixed in stac-fastapi main, but unreleased). With the incorrect advertisements, pystac_client throws an error when trying to sort.

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the changelog