### PR TITLE
fix docker deploy image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+elasticsearch/snapshots/
+.venv

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -2,6 +2,7 @@ FROM python:3.10-slim
 
 RUN apt-get update && \
     apt-get -y upgrade && \
+    apt-get -y install gcc && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Description:**

- fix docker deploy image, which now requires gcc to build because of a new dependency

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the changelog