### PR TITLE
Adding optional page argument to all_collections endpoint.

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -59,12 +59,12 @@ class CoreClient(AsyncBaseCoreClient):
         base_url = str(kwargs["request"].base_url)
         request = kwargs["request"]
         page_str = None
-        if(request.query_params is not None):
-            page_str = request.query_params.get('page')
+        if request.query_params is not None:
+            page_str = request.query_params.get("page")
         pageint = 1
-        if(page_str is not None):
+        if page_str is not None:
             pageint = int(page_str)
-        if (pageint<1):
+        if pageint < 1:
             pageint = 1
 
         return Collections(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -387,8 +387,7 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             return None  # type: ignore
         else:
             item = await self.database.prep_create_item(item=item, base_url=base_url)
-            # await self.database.create_item(item, refresh=kwargs.get("refresh", False))
-            await self.database.create_item(item, refresh=True)
+            await self.database.create_item(item, refresh=kwargs.get("refresh", False))
             return item
 
     @overrides

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -57,11 +57,20 @@ class CoreClient(AsyncBaseCoreClient):
     async def all_collections(self, **kwargs) -> Collections:
         """Read all collections from the database."""
         base_url = str(kwargs["request"].base_url)
+        request = kwargs["request"]
+        page_str = None
+        if(request.query_params is not None):
+            page_str = request.query_params.get('page')
+        pageint = 1
+        if(page_str is not None):
+            pageint = int(page_str)
+        if (pageint<1):
+            pageint = 1
 
         return Collections(
             collections=[
                 self.collection_serializer.db_to_stac(c, base_url=base_url)
-                for c in await self.database.get_all_collections()
+                for c in await self.database.get_all_collections(page=pageint)
             ],
             links=[
                 {
@@ -378,7 +387,8 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             return None  # type: ignore
         else:
             item = await self.database.prep_create_item(item=item, base_url=base_url)
-            await self.database.create_item(item, refresh=kwargs.get("refresh", False))
+            # await self.database.create_item(item, refresh=kwargs.get("refresh", False))
+            await self.database.create_item(item, refresh=True)
             return item
 
     @overrides

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -214,9 +214,9 @@ class DatabaseLogic:
     async def get_all_collections(self, page: int = 1) -> Iterable[Dict[str, Any]]:
         """Database logic to retrieve a list of all collections."""
         results_after = (page - 1) * COLLECTIONS_PAGE_SIZE
-        collections = await self.client.search(index=COLLECTIONS_INDEX,
-                                               size=COLLECTIONS_PAGE_SIZE,
-                                               from_=results_after)
+        collections = await self.client.search(
+            index=COLLECTIONS_INDEX, size=COLLECTIONS_PAGE_SIZE, from_=results_after
+        )
         return (c["_source"] for c in collections["hits"]["hits"])
 
     async def get_one_item(self, collection_id: str, item_id: str) -> Dict:
@@ -447,9 +447,7 @@ class DatabaseLogic:
                 f"Item {item_id} in collection {collection_id} already exists"
             )
 
-    async def delete_item(
-        self, item_id: str, collection_id: str, refresh: bool = True
-    ):
+    async def delete_item(self, item_id: str, collection_id: str, refresh: bool = True):
         """Database logic for deleting one item."""
         try:
             await self.client.delete(

--- a/stac_fastapi/elasticsearch/tests/conftest.py
+++ b/stac_fastapi/elasticsearch/tests/conftest.py
@@ -40,6 +40,7 @@ class Context:
 
 class MockRequest:
     base_url = "http://test-server"
+    query_params = None
 
     def __init__(
         self, method: str = "GET", url: str = "XXXX", app: Optional[Any] = None

--- a/stac_fastapi/elasticsearch/tests/resources/test_collection.py
+++ b/stac_fastapi/elasticsearch/tests/resources/test_collection.py
@@ -1,5 +1,3 @@
-import json
-
 import pystac
 import pytest
 

--- a/stac_fastapi/elasticsearch/tests/resources/test_collection.py
+++ b/stac_fastapi/elasticsearch/tests/resources/test_collection.py
@@ -1,6 +1,8 @@
+import json
+
 import pystac
 import pytest
-import json
+
 
 async def test_create_and_delete_collection(app_client, load_test_data):
     """Test creation and deletion of a collection"""
@@ -13,7 +15,10 @@ async def test_create_and_delete_collection(app_client, load_test_data):
     resp = await app_client.delete(f"/collections/{test_collection['id']}")
     assert resp.status_code == 200
 
-@pytest.mark.skip(reason="paginating collections takes a long time to test, skip it if you haven't changed anything")
+
+@pytest.mark.skip(
+    reason="paginating collections takes a long time to test, skip it if you haven't changed anything"
+)
 async def test_create_paginate_collections(app_client, load_test_data):
     """Test creation and pagination of collections"""
     test_collection = load_test_data("test_collection.json")
@@ -24,12 +29,14 @@ async def test_create_paginate_collections(app_client, load_test_data):
         resp = await app_client.post("/collections", json=test_collection)
         assert resp.status_code == 200
 
-    resp = await app_client.get("/collections?page=2")#, params={"page": 2})
+    resp = await app_client.get("/collections?page=2")  # , params={"page": 2})
     resp_json = resp.json()
     collcount = len(resp_json["collections"])
     assert collcount == 4
 
     """ this many deletes all at once tends to error out after a certain point """
+
+
 #    for i in range(1, 1005):
 #        test_id = "test_" + str(i)
 #        resp = await app_client.delete(f"/collections/{test_id}")

--- a/stac_fastapi/elasticsearch/tests/resources/test_collection.py
+++ b/stac_fastapi/elasticsearch/tests/resources/test_collection.py
@@ -1,5 +1,6 @@
 import pystac
-
+import pytest
+import json
 
 async def test_create_and_delete_collection(app_client, load_test_data):
     """Test creation and deletion of a collection"""
@@ -11,6 +12,28 @@ async def test_create_and_delete_collection(app_client, load_test_data):
 
     resp = await app_client.delete(f"/collections/{test_collection['id']}")
     assert resp.status_code == 200
+
+@pytest.mark.skip(reason="paginating collections takes a long time to test, skip it if you haven't changed anything")
+async def test_create_paginate_collections(app_client, load_test_data):
+    """Test creation and pagination of collections"""
+    test_collection = load_test_data("test_collection.json")
+    test_collection["id"] = "test"
+
+    for i in range(1, 1005):
+        test_collection["id"] = "test_" + str(i)
+        resp = await app_client.post("/collections", json=test_collection)
+        assert resp.status_code == 200
+
+    resp = await app_client.get("/collections?page=2")#, params={"page": 2})
+    resp_json = resp.json()
+    collcount = len(resp_json["collections"])
+    assert collcount == 4
+
+    """ this many deletes all at once tends to error out after a certain point """
+#    for i in range(1, 1005):
+#        test_id = "test_" + str(i)
+#        resp = await app_client.delete(f"/collections/{test_id}")
+#        assert resp.status_code == 200
 
 
 async def test_create_collection_conflict(app_client, ctx):


### PR DESCRIPTION
**Related Issue(s):**

- #65 

**Description:**
Adds an optional "page" argument for all_collections endpoint.

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the changelog