### PR TITLE
Update pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         args: [ '--safe' ]
@@ -18,7 +18,7 @@ repos:
           # E203 black conflicts with "whitespace before ':'" rule
           '--ignore=E501,W503,E203,C901' ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.991
     hooks:
       - id: mypy
         exclude: /tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,12 @@ repos:
       - id: mypy
         exclude: /tests/
         # --strict
-        args: [--no-strict-optional, --ignore-missing-imports, --implicit-reexport]
+        args: [
+          --no-strict-optional,
+          --ignore-missing-imports,
+          --implicit-reexport,
+          --explicit-package-bases,
+        ]
         additional_dependencies: [
           "types-attrs",
           "types-requests"


### PR DESCRIPTION
**Description:**

This upgrades the black and mypy hook versions.

Note that flake8 is upgraded separately in #123.

The mypy change introduced the following errors, which are now addressed by adding the `--explicit-package-bases` argument to the mypy invocation:

```
stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/datetime_utils.py: error: Source file found twice under different module names: "elasticsearch.datetime_utils" and "stac_fastapi.elasticsearch.datetime_utils"
stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/datetime_utils.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/datetime_utils.py: note: Common resolutions include: a) adding `__init__.py` somewhere, b) using `--explicit-package-bases` or adjusting MYPYPATH
```

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the changelog