### PR TITLE
ES index names configurables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- The default collection objects index can be overridden by the `STAC_COLLECTIONS_INDEX` environment variable.
-- The Item objects index prefix can be overridden by the `STAC_ITEMS_INDEX_PREFIX` environment variable.
+- The default Collection objects index can be overridden by the `STAC_COLLECTIONS_INDEX` environment variable.
+- The defualt Item objects index prefix can be overridden by the `STAC_ITEMS_INDEX_PREFIX` environment variable.
 
 ## [v0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- The default collection objects index can be overridden by the `STAC_COLLECTIONS_INDEX` environment variable.
+- The Item objects index prefix can be overridden by the `STAC_ITEMS_INDEX_PREFIX` environment variable.
+
 ## [v0.2.0]
 
 ### Deprecated
 
 ### Added
 
-- Filter Extension as GET with CQL2-Text and POST with CQL2-JSON, 
+- Filter Extension as GET with CQL2-Text and POST with CQL2-JSON,
   supporting the Basic CQL2 and Basic Spatial Operators conformance classes.
 - Added Elasticsearch local config to support snapshot/restore to local filesystem
 
@@ -44,7 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Elasticsearch index mappings updated to be more thorough.
 - Endpoints that return items (e.g., /search) now sort the results by 'properties.datetime,id,collection'.
   Previously, there was no sort order defined.
-- Db_to_stac serializer moved to core.py for consistency as it existed in both core and database_logic previously. 
+- Db_to_stac serializer moved to core.py for consistency as it existed in both core and database_logic previously.
 - Use genexp in execute_search and get_all_collections to return results.
 - Added db_to_stac serializer to item_collection method in core.py.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - The default Collection objects index can be overridden by the `STAC_COLLECTIONS_INDEX` environment variable.
-- The defualt Item objects index prefix can be overridden by the `STAC_ITEMS_INDEX_PREFIX` environment variable.
+- The default Item objects index prefix can be overridden by the `STAC_ITEMS_INDEX_PREFIX` environment variable.
 
 ## [v0.2.0]
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1,7 +1,7 @@
 """Database logic."""
-import os
 import asyncio
 import logging
+import os
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from typing import Any, Dict, Iterable, List, Optional, Protocol, Tuple, Type, Union
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1,4 +1,5 @@
 """Database logic."""
+import os
 import asyncio
 import logging
 from base64 import urlsafe_b64decode, urlsafe_b64encode
@@ -21,8 +22,8 @@ logger = logging.getLogger(__name__)
 
 NumType = Union[float, int]
 
-COLLECTIONS_INDEX = "collections"
-ITEMS_INDEX_PREFIX = "items_"
+COLLECTIONS_INDEX = os.getenv("STAC_COLLECTIONS_INDEX", "collections")
+ITEMS_INDEX_PREFIX = os.getenv("STAC_ITEMS_INDEX_PREFIX", "items_")
 
 DEFAULT_INDICES = f"*,-*kibana*,-{COLLECTIONS_INDEX}"
 


### PR DESCRIPTION
**Related Issue(s):**

- #126

**Description:**

Allows to define custom ES index name for "collections" and "items"

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the changelog