### PR TITLE
[FIX-135]: Fix automatic converstion of float values to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Corrected the closing of client connections in ES index management functions [#132](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/132)
+- Corrected the automatic converstion of float values to int when building Filter Clauses [#135](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/135)
 
 ## [v0.3.0]
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/extensions/filter.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/extensions/filter.py
@@ -114,6 +114,23 @@ class Date(BaseModel):
         return self.date.isoformat()
 
 
+class FloatInt(float):
+    """Representation of Float/Int."""
+
+    @classmethod
+    def __get_validators__(cls):
+        """Return validator to use."""
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        """Validate input value."""
+        if isinstance(v, float):
+            return v
+        else:
+            return int(v)
+
+
 Arg = Union[
     "Clause",
     PropertyReference,
@@ -126,8 +143,7 @@ Arg = Union[
     Polygon,
     MultiPolygon,
     GeometryCollection,
-    int,
-    float,
+    FloatInt,
     str,
     bool,
 ]

--- a/stac_fastapi/elasticsearch/tests/extensions/test_filter.py
+++ b/stac_fastapi/elasticsearch/tests/extensions/test_filter.py
@@ -78,3 +78,34 @@ async def test_search_filter_ext_and(app_client, ctx):
 
     assert resp.status_code == 200
     assert len(resp.json()["features"]) == 1
+
+
+async def test_search_filter_extension_floats(app_client, ctx):
+    sun_elevation = ctx.item["properties"]["view:sun_elevation"]
+
+    params = {
+        "filter": {
+            "op": "and",
+            "args": [
+                {"op": "=", "args": [{"property": "id"}, ctx.item["id"]]},
+                {
+                    "op": ">",
+                    "args": [
+                        {"property": "properties.view:sun_elevation"},
+                        sun_elevation - 0.01,
+                    ],
+                },
+                {
+                    "op": "<",
+                    "args": [
+                        {"property": "properties.view:sun_elevation"},
+                        sun_elevation + 0.01,
+                    ],
+                },
+            ],
+        }
+    }
+    resp = await app_client.post("/search", json=params)
+
+    assert resp.status_code == 200
+    assert len(resp.json()["features"]) == 1


### PR DESCRIPTION
**Related Issue(s):**

- #135

**Description:**
Searching items filtering by properties with floats returns wrong results. [Clause](https://github.com/stac-utils/stac-fastapi-elasticsearch/blob/main/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/extensions/filter.py#L117) converts input query to ES filter using this Union. Because int is defined before float, all numeric values are converted to integer.

This fix takes care of value types, do not converting floats to int.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog