### PR TITLE
do not index proj:geometry and proj:centroid as geo fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Corrected the closing of client connections in ES index management functions [#132](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/132)
 - Corrected the automatic converstion of float values to int when building Filter Clauses [#135](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/135)
+- Do not index `proj:geometry` and `proj:centroid` fields as geo shapes [#154](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/154)
 
 ## [v0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Corrected the closing of client connections in ES index management functions [#132](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/132)
 - Corrected the automatic converstion of float values to int when building Filter Clauses [#135](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/135)
-- Do not index `proj:geometry` and `proj:centroid` fields as geo shapes [#154](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/154)
+- Do not index `proj:geometry` field as geo_shape [#154](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/154)
 - Remove unsupported characters from Elasticsearch index names [#153](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/153)
 
 ## [v0.3.0]

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -81,7 +81,7 @@ ES_MAPPINGS_DYNAMIC_TEMPLATES = [
     {
         "proj_centroid": {
             "match": "proj:centroid",
-            "mapping": {"type": "object", "enabled": False},
+            "mapping": {"type": "geo_point"},
         }
     },
     {

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -67,13 +67,13 @@ ES_MAPPINGS_DYNAMIC_TEMPLATES = [
     {
         "proj_centroid": {
             "match": "proj:centroid",
-            "mapping": {"type": "geo_point"},
+            "mapping": {"type": "object", "enabled": False},
         }
     },
     {
         "proj_geometry": {
             "match": "proj:geometry",
-            "mapping": {"type": "geo_shape"},
+            "mapping": {"type": "object", "enabled": False},
         }
     },
     {


### PR DESCRIPTION
**Related Issue(s):**

- #154 

**Description:**
Do not index `proj:geometry` and `proj:centroid` as geo fields.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog