### PR TITLE
Exclude unset fields in search response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Exclude unset fields in search response [#166](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/166)
 
 ## [v1.0.0]
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -509,7 +509,9 @@ class CoreClient(AsyncBaseCoreClient):
             filter_kwargs = search_request.fields.filter_fields
 
             items = [
-                orjson.loads(stac_pydantic.Item(**feat).json(**filter_kwargs))
+                orjson.loads(
+                    stac_pydantic.Item(**feat).json(**filter_kwargs, exclude_unset=True)
+                )
                 for feat in items
             ]
 


### PR DESCRIPTION
**Related Issue(s):**

- #166 

**Description:**
Exclude unset fields in search response when Fields extension is enabled.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog