### PR TITLE
Set correct default filter-lang for GET /search requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Exclude unset fields in search response [#166](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/166)
 - Upgrade stac-fastapi to v2.4.9 [#172](https://github.com/stac-utils/stac-fastapi-elasticsearch/pull/172)
+- Set correct default filter-lang for GET /search requests [#179](https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/179)
 
 ## [v1.0.0]
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/core.py
@@ -380,12 +380,12 @@ class CoreClient(AsyncBaseCoreClient):
             base_args["sortby"] = sort_param
 
         if filter:
-            if filter_lang == "cql2-text":
-                base_args["filter-lang"] = "cql2-json"
-                base_args["filter"] = orjson.loads(to_cql2(parse_cql2_text(filter)))
-            else:
+            if filter_lang == "cql2-json":
                 base_args["filter-lang"] = "cql2-json"
                 base_args["filter"] = orjson.loads(unquote_plus(filter))
+            else:
+                base_args["filter-lang"] = "cql2-json"
+                base_args["filter"] = orjson.loads(to_cql2(parse_cql2_text(filter)))
 
         if fields:
             includes = set()

--- a/stac_fastapi/elasticsearch/tests/extensions/test_filter.py
+++ b/stac_fastapi/elasticsearch/tests/extensions/test_filter.py
@@ -102,6 +102,17 @@ async def test_search_filter_ext_and_get(app_client, ctx):
 
 
 @pytest.mark.asyncio
+async def test_search_filter_ext_and_get_id(app_client, ctx):
+    collection = ctx.item["collection"]
+    id = ctx.item["id"]
+    filter = f"id='{id}' AND collection='{collection}'"
+    resp = await app_client.get(f"/search?&filter={filter}")
+
+    assert resp.status_code == 200
+    assert len(resp.json()["features"]) == 1
+
+
+@pytest.mark.asyncio
 async def test_search_filter_ext_and_get_cql2text_id(app_client, ctx):
     collection = ctx.item["collection"]
     id = ctx.item["id"]
@@ -162,21 +173,21 @@ async def test_search_filter_ext_and_post(app_client, ctx):
 @pytest.mark.asyncio
 async def test_search_filter_extension_floats_get(app_client, ctx):
     resp = await app_client.get(
-        """/search?filter={"op":"and","args":[{"op":"=","args":[{"property":"id"},"test-item"]},{"op":">","args":[{"property":"properties.view:sun_elevation"},"-37.30891534"]},{"op":"<","args":[{"property":"properties.view:sun_elevation"},"-37.30691534"]}]}"""
+        """/search?filter-lang=cql2-json&filter={"op":"and","args":[{"op":"=","args":[{"property":"id"},"test-item"]},{"op":">","args":[{"property":"properties.view:sun_elevation"},"-37.30891534"]},{"op":"<","args":[{"property":"properties.view:sun_elevation"},"-37.30691534"]}]}"""
     )
 
     assert resp.status_code == 200
     assert len(resp.json()["features"]) == 1
 
     resp = await app_client.get(
-        """/search?filter={"op":"and","args":[{"op":"=","args":[{"property":"id"},"test-item-7"]},{"op":">","args":[{"property":"properties.view:sun_elevation"},"-37.30891534"]},{"op":"<","args":[{"property":"properties.view:sun_elevation"},"-37.30691534"]}]}"""
+        """/search?filter-lang=cql2-json&filter={"op":"and","args":[{"op":"=","args":[{"property":"id"},"test-item-7"]},{"op":">","args":[{"property":"properties.view:sun_elevation"},"-37.30891534"]},{"op":"<","args":[{"property":"properties.view:sun_elevation"},"-37.30691534"]}]}"""
     )
 
     assert resp.status_code == 200
     assert len(resp.json()["features"]) == 0
 
     resp = await app_client.get(
-        """/search?filter={"op":"and","args":[{"op":"=","args":[{"property":"id"},"test-item"]},{"op":">","args":[{"property":"properties.view:sun_elevation"},"-37.30591534"]},{"op":"<","args":[{"property":"properties.view:sun_elevation"},"-37.30491534"]}]}"""
+        """/search?filter-lang=cql2-json&filter={"op":"and","args":[{"op":"=","args":[{"property":"id"},"test-item"]},{"op":">","args":[{"property":"properties.view:sun_elevation"},"-37.30591534"]},{"op":"<","args":[{"property":"properties.view:sun_elevation"},"-37.30491534"]}]}"""
     )
 
     assert resp.status_code == 200


### PR DESCRIPTION
**Related Issue(s):**
- #179 

**Description:**
Set correct default filter-lang for GET /search requests

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog