### PR TITLE
v6.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Ensure `REDIS_MAX_CONNECTION` can accept `None` and integer value for default number of connection. [#515](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/515)
-
 ### Removed
 
 ### Updated
+
+## [v6.7.1] - 2025-10-31
+
+### Fixed
+
+- Ensure `REDIS_MAX_CONNECTION` can accept `None` and integer value for default number of connection. [#515](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/515)
 
 ## [v6.7.0] - 2025-10-27
 
@@ -611,7 +615,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use genexp in execute_search and get_all_collections to return results.
 - Added db_to_stac serializer to item_collection method in core.py.
 
-[Unreleased]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.7.0...main
+[Unreleased]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.7.1...main
+[v6.7.1]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.7.0...v6.7.1
 [v6.7.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.6.0...v6.7.0
 [v6.6.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.5.1...v6.6.0
 [v6.5.1]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.5.0...v6.5.1

--- a/stac_fastapi/core/stac_fastapi/core/version.py
+++ b/stac_fastapi/core/stac_fastapi/core/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.7.0"
+__version__ = "6.7.1"

--- a/stac_fastapi/elasticsearch/pyproject.toml
+++ b/stac_fastapi/elasticsearch/pyproject.toml
@@ -30,8 +30,8 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "stac-fastapi-core==6.7.0",
-    "sfeos-helpers==6.7.0",
+    "stac-fastapi-core==6.7.1",
+    "sfeos-helpers==6.7.1",
     "elasticsearch[async]~=8.19.1",
     "uvicorn~=0.23.0",
     "starlette>=0.35.0,<0.36.0",

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.7.0"
+__version__ = "6.7.1"

--- a/stac_fastapi/opensearch/pyproject.toml
+++ b/stac_fastapi/opensearch/pyproject.toml
@@ -30,8 +30,8 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "stac-fastapi-core==6.7.0",
-    "sfeos-helpers==6.7.0",
+    "stac-fastapi-core==6.7.1",
+    "sfeos-helpers==6.7.1",
     "opensearch-py~=2.8.0",
     "opensearch-py[async]~=2.8.0",
     "uvicorn~=0.23.0",

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.7.0"
+__version__ = "6.7.1"

--- a/stac_fastapi/sfeos_helpers/pyproject.toml
+++ b/stac_fastapi/sfeos_helpers/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "stac-fastapi.core==6.7.0",
+    "stac-fastapi.core==6.7.1",
 ]
 
 [project.urls]

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.7.0"
+__version__ = "6.7.1"


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**

- Ensure `REDIS_MAX_CONNECTION` can accept `None` and integer value for default number of connection. [#515](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/515)


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog