### PR TITLE
fix: ensure datetime in post request is normalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed datetime filtering for .0Z milliseconds to preserve precision in apply_filter_datetime, ensuring only items exactly within the specified range are returned. [#535](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/535)
+- Normalize datetime in POST /search requests to match GET /search behavior. [#543](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/543)
 
 ### Removed
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -790,9 +790,10 @@ class CoreClient(AsyncBaseCoreClient):
                 search=search, collection_ids=search_request.collections
             )
 
+        datetime_parsed = format_datetime_range(date_str=search_request.datetime)
         try:
             search, datetime_search = self.database.apply_datetime_filter(
-                search=search, datetime=search_request.datetime
+                search=search, datetime=datetime_parsed
             )
         except (ValueError, TypeError) as e:
             # Handle invalid interval formats if return_date fails


### PR DESCRIPTION
**Description:**

Currently, in `POST` requests to `/search`, with datetime values are not normalized as they are in `GET` requests to `/search`, which can cause different results to be returned for the same datetime filter. For example:
`POST` request to `/search` with `datetime=2025-11-20T09:54:38Z/2025-11-20T09:54:38Z` returns an item with `2025-11-20T09:54:38.196614Z`, whereas a GET request with the same datetime filter does not which is expected behavior. This PR ensures that datetime values in `POST` requests are normalized in the same way as in `GET` requests.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog