### PR TITLE
Implement CQL2-JSON AST for datetime index selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added CQL2 Abstract Syntax Tree (AST) structure for efficient query parsing and datetime-based indexes. [#560](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/560)
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ This project is built on the following technologies: STAC, stac-fastapi, FastAPI
   - [Examples](#examples)
   - [Performance](#performance)
     - [Direct Response Mode](#direct-response-mode)
+    - [CQL2 JSON Search with AST-based Parsing]
+(#cql2-json-search-with-ast-based-parsing)
   - [Quick Start](#quick-start)
     - [Installation](#installation)
     - [Running Locally](#running-locally)
@@ -510,6 +512,30 @@ These examples provide practical reference implementations for various deploymen
 - **Best use case**: This mode is best suited for public or read-only APIs where authentication and custom logic are not required.
 - **Default setting**: `false` for safety.
 - **More information**: See [issue #347](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/issues/347) for background and implementation details.
+
+### CQL2 JSON Search with AST-based Parsing
+
+SFEOS now uses an Abstract Syntax Tree (AST) in CQL2-JSON search queries for efficient query parsing and datetime extraction, enabling the selection and management of the appropriate searchable indexes.
+
+#### AST-based Query Processing
+
+The CQL2 implementation uses an Abstract Syntax Tree (AST) structure that replaces the previous dictionary-based processing. This enables:
+
+1. **Structured Query Representation**: Queries are parsed into a tree structure with different node types
+2. **Efficient Parameter Access**: Easy traversal and extraction of query parameters
+3. **Optimized Index Selection**: Selection of appropriate fields for selection and management of indexes
+
+#### AST Node Types
+
+The AST supports various node types representing different query operations:
+
+- **Logical Nodes**: `AND`, `OR`, `NOT` operators for combining conditions
+- **Comparison Nodes**: `=`, `<>`, `<`, `<=`, `>`, `>=`, `isNull` operations
+- **Advanced Comparison Nodes**: `LIKE`, `BETWEEN`, `IN` operations
+- **Spatial Nodes**: `s_intersects`, `s_contains`, `s_within`, `s_disjoint` for geospatial queries
+- **Datetime Nodes**: Special handling for datetime range and exact value queries
+
+The AST-based approach enables efficient extraction of datetime parameters (`datetime`, `start_datetime`, `end_datetime`) from complex queries.
 
 ## Quick Start
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -853,6 +853,8 @@ class CoreClient(AsyncBaseCoreClient):
                 search=search, intersects=getattr(search_request, "intersects")
             )
 
+        collection_ids = getattr(search_request, "collections", None)
+
         if hasattr(search_request, "query") and getattr(search_request, "query"):
             query_fields = set(getattr(search_request, "query").keys())
             await self.queryables_cache.validate(query_fields)
@@ -909,7 +911,7 @@ class CoreClient(AsyncBaseCoreClient):
             limit=limit,
             token=token_param,
             sort=sort,
-            collection_ids=getattr(search_request, "collections", None),
+            collection_ids=collection_ids,
             datetime_search=datetime_search,
         )
 

--- a/stac_fastapi/core/stac_fastapi/core/extensions/filter.py
+++ b/stac_fastapi/core/stac_fastapi/core/extensions/filter.py
@@ -13,8 +13,9 @@
 # defines spatial operators (S_INTERSECTS, S_CONTAINS, S_WITHIN, S_DISJOINT).
 # """
 
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 DEFAULT_QUERYABLES: Dict[str, Dict[str, Any]] = {
     "id": {
@@ -90,3 +91,62 @@ class SpatialOp(str, Enum):
     S_CONTAINS = "s_contains"
     S_WITHIN = "s_within"
     S_DISJOINT = "s_disjoint"
+
+
+@dataclass
+class CqlNode:
+    """Base class."""
+
+    pass
+
+
+@dataclass
+class LogicalNode(CqlNode):
+    """Logical operators (AND, OR, NOT)."""
+
+    op: LogicalOp
+    children: List["CqlNode"]
+
+
+@dataclass
+class ComparisonNode(CqlNode):
+    """Comparison operators (=, <>, <, <=, >, >=, is null)."""
+
+    op: ComparisonOp
+    field: str
+    value: Any
+
+
+@dataclass
+class AdvancedComparisonNode(CqlNode):
+    """Advanced comparison operators (like, between, in)."""
+
+    op: AdvancedComparisonOp
+    field: str
+    value: Any
+
+
+@dataclass
+class SpatialNode(CqlNode):
+    """Spatial operators."""
+
+    op: SpatialOp
+    field: str
+    geometry: Dict[str, Any]
+
+
+@dataclass
+class DateTimeRangeNode(CqlNode):
+    """Datetime range queries."""
+
+    field: str = "properties.datetime"
+    start: Optional[str] = None
+    end: Optional[str] = None
+
+
+@dataclass
+class DateTimeExactNode(CqlNode):
+    """Exact datetime queries."""
+
+    field: str = "properties.datetime"
+    value: Optional[str] = None

--- a/stac_fastapi/core/stac_fastapi/core/version.py
+++ b/stac_fastapi/core/stac_fastapi/core/version.py
@@ -1,2 +1,3 @@
 """library version."""
+
 __version__ = "6.10.1"

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1,4 +1,5 @@
 """Database logic."""
+
 import asyncio
 import logging
 import os

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -60,6 +60,7 @@ from stac_fastapi.sfeos_helpers.database.utils import (
     merge_to_operations,
     operations_to_script,
 )
+from stac_fastapi.sfeos_helpers.filter import build_cql2_filter, resolve_cql2_indexes
 from stac_fastapi.sfeos_helpers.mappings import (
     AGGREGATION_MAPPING,
     COLLECTIONS_INDEX,
@@ -783,9 +784,9 @@ class DatabaseLogic(BaseDatabaseLogic):
         """
         Apply a CQL2 filter to an Elasticsearch Search object.
 
-        This method transforms a dictionary representing a CQL2 filter into an Elasticsearch query
-        and applies it to the provided Search object. If the filter is None, the original Search
-        object is returned unmodified.
+        This method transforms a CQL2 filter dictionary into an Elasticsearch query using
+        an AST tree-based approach. If the filter is None, the original Search object is returned
+        unmodified.
 
         Args:
             search (Search): The Elasticsearch Search object to which the filter will be applied.
@@ -799,8 +800,20 @@ class DatabaseLogic(BaseDatabaseLogic):
                     otherwise the original Search object.
         """
         if _filter is not None:
-            es_query = filter_module.to_es(await self.get_queryables_mapping(), _filter)
-            search = search.query(es_query)
+            queryables_mapping = await self.get_queryables_mapping()
+
+            try:
+                es_query, metadata = build_cql2_filter(queryables_mapping, _filter)
+                search = search.filter(es_query)
+                search._cql2_metadata = metadata
+
+            except Exception as e:
+                logger.warning(
+                    "Failed to build CQL2 filter using AST tree approach, falling back to dictionary-based method. "
+                    f"Error: {str(e)}. Filter: {_filter}"
+                )
+                es_query = filter_module.to_es(queryables_mapping, _filter)
+                search = search.filter(es_query)
 
         return search
 
@@ -857,10 +870,20 @@ class DatabaseLogic(BaseDatabaseLogic):
             search_after = orjson.loads(urlsafe_b64decode(token))
 
         query = search.query.to_dict() if search.query else None
+        cql2_metadata = getattr(search, "_cql2_metadata", None)
 
-        index_param = await self.async_index_selector.select_indexes(
-            collection_ids, datetime_search
-        )
+        # Special case for cql2-json index selection
+        if cql2_metadata:
+            index_param, collection_ids = await resolve_cql2_indexes(
+                cql2_metadata,
+                self.async_index_selector,
+                self.apply_datetime_filter,
+                search,
+            )
+        else:
+            index_param = await self.async_index_selector.select_indexes(
+                collection_ids, datetime_search
+            )
         if len(index_param) > ES_MAX_URL_LENGTH - 300:
             index_param = ITEM_INDICES
             query = add_collections_to_body(collection_ids, query)

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
@@ -1,2 +1,3 @@
 """library version."""
+
 __version__ = "6.10.1"

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -1,4 +1,5 @@
 """Database logic."""
+
 import asyncio
 import logging
 import os
@@ -877,9 +878,21 @@ class DatabaseLogic(BaseDatabaseLogic):
                 self.apply_datetime_filter,
                 search,
             )
+            logger.debug(
+                f"Resolve indexes from CQL2 metadata: {index_param} for collections {collection_ids} and cql2 metadata {cql2_metadata}"
+            )
+            print(
+                f"Resolve indexes from CQL2 metadata: {index_param} for collections {collection_ids} and cql2 metadata {cql2_metadata}"
+            )
         else:
             index_param = await self.async_index_selector.select_indexes(
                 collection_ids, datetime_search
+            )
+            logger.debug(
+                f"Selecte indexes: {index_param} for collections {collection_ids} and datetime search {datetime_search}"
+            )
+            print(
+                f"Selecte indexes: {index_param} for collections {collection_ids} and datetime search {datetime_search}"
             )
         if len(index_param) > ES_MAX_URL_LENGTH - 300:
             index_param = ITEM_INDICES

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
@@ -1,2 +1,3 @@
 """library version."""
+
 __version__ = "6.10.1"

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/aggregation/client.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/aggregation/client.py
@@ -1,6 +1,5 @@
 """Client implementation for the STAC API Aggregation Extension."""
 
-
 from typing import Annotated, Any, Dict, List, Optional, Union
 from urllib.parse import unquote_plus, urljoin
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/__init__.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/__init__.py
@@ -11,6 +11,8 @@ The filter package is organized as follows:
 - cql2.py: CQL2 pattern conversion helpers
 - transform.py: Query transformation functions
 - client.py: Filter client implementation
+- ast_parser.py: AST parser for CQL2 queries
+- datetime_optimizer.py: Datetime optimization for query structure
 
 When adding new functionality to this package, consider:
 1. Will this code be used by both Elasticsearch and OpenSearch implementations?
@@ -22,15 +24,26 @@ Function Naming Conventions:
 - Parameter names should be consistent across similar functions
 """
 
+from stac_fastapi.core.extensions.filter import (
+    AdvancedComparisonOp,
+    ComparisonOp,
+    LogicalOp,
+)
+
+from .ast_parser import Cql2AstParser
+from .ast_transform import to_es_via_ast
 from .client import EsAsyncBaseFiltersClient
 
 # Re-export the main functions and classes for backward compatibility
 from .cql2 import (
     _replace_like_patterns,
+    build_cql2_filter,
     cql2_like_patterns,
     cql2_like_to_es,
+    resolve_cql2_indexes,
     valid_like_substitutions,
 )
+from .datetime_optimizer import DatetimeOptimizer
 from .transform import to_es, to_es_field
 
 __all__ = [
@@ -40,5 +53,14 @@ __all__ = [
     "_replace_like_patterns",
     "to_es_field",
     "to_es",
+    "to_es_via_ast",
     "EsAsyncBaseFiltersClient",
+    "Cql2AstParser",
+    "AdvancedComparisonOp",
+    "ComparisonOp",
+    "LogicalOp",
+    "DatetimeOptimizer",
+    "extract_from_ast",
+    "resolve_cql2_indexes",
+    "build_cql2_filter",
 ]

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/ast_parser.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/ast_parser.py
@@ -1,0 +1,113 @@
+"""AST parser for CQL2 queries."""
+
+import json
+from typing import Any, Dict, Union
+
+from stac_fastapi.core.extensions.filter import (
+    AdvancedComparisonNode,
+    AdvancedComparisonOp,
+    ComparisonNode,
+    ComparisonOp,
+    CqlNode,
+    LogicalNode,
+    LogicalOp,
+    SpatialNode,
+    SpatialOp,
+)
+
+
+class Cql2AstParser:
+    """Parse CQL2 into AST tree."""
+
+    def __init__(self, queryables_mapping: Dict[str, Any]):
+        """Initialize the CQL2 AST parser."""
+        self.queryables_mapping = queryables_mapping
+
+    def parse(self, cql: Union[str, Dict[str, Any]]) -> CqlNode:
+        """Parse CQL2 into AST tree.
+
+        Args:
+            cql: CQL2 expression as string/dictionary
+
+        Returns:
+            Node of AST tree
+        """
+        if isinstance(cql, str):
+            data: Dict[str, Any] = json.loads(cql)
+            return self._parse_node(data)
+
+        return self._parse_node(cql)
+
+    def _parse_node(self, node: Dict[str, Any]) -> CqlNode:
+        """Parse a single CQL2 node into AST."""
+        if "op" in node and node["op"] in ["and", "or", "not"]:
+            op = LogicalOp(node["op"])
+            args = node.get("args", [])
+
+            if op == LogicalOp.NOT:
+                children = [self._parse_node(args[0])] if args else []
+            else:
+                children = [self._parse_node(arg) for arg in args]
+
+            return LogicalNode(op=op, children=children)
+
+        elif "op" in node and node["op"] in ["=", "<>", "<", "<=", ">", ">=", "isNull"]:
+            op = ComparisonOp(node["op"])
+            args = node.get("args", [])
+
+            if isinstance(args[0], dict) and "property" in args[0]:
+                field = args[0]["property"]
+            else:
+                field = str(args[0])
+
+            value = args[1] if len(args) > 1 else None
+
+            return ComparisonNode(op=op, field=field, value=value)
+
+        elif "op" in node and node["op"] in ["like", "between", "in"]:
+            op = AdvancedComparisonOp(node["op"])
+            args = node.get("args", [])
+
+            if isinstance(args[0], dict) and "property" in args[0]:
+                field = args[0]["property"]
+            else:
+                field = str(args[0])
+
+            if op == AdvancedComparisonOp.BETWEEN:
+                if len(args) != 3:
+                    raise ValueError(
+                        f"BETWEEN operator requires (property, lower, upper), got {args}"
+                    )
+                value = (args[1], args[2])
+
+            elif op == AdvancedComparisonOp.IN:
+                if not isinstance(args[1], list):
+                    raise ValueError(f"IN operator expects list, got {type(args[1])}")
+                value = args[1]
+
+            elif op == AdvancedComparisonOp.LIKE:
+                if len(args) != 2:
+                    raise ValueError(
+                        f"LIKE operator requires (property, pattern), got {args}"
+                    )
+                value = args[1]
+
+            return AdvancedComparisonNode(op=op, field=field, value=value)
+
+        elif "op" in node and node["op"] in [
+            "s_intersects",
+            "s_contains",
+            "s_within",
+            "s_disjoint",
+        ]:
+            op = SpatialOp(node["op"])
+            args = node.get("args", [])
+
+            if isinstance(args[0], dict) and "property" in args[0]:
+                field = args[0]["property"]
+            else:
+                field = str(args[0])
+
+            geometry = args[1]
+
+            return SpatialNode(op=op, field=field, geometry=geometry)

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/ast_transform.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/ast_transform.py
@@ -1,0 +1,151 @@
+"""AST-based query transformation for Elasticsearch/OpenSearch."""
+
+from typing import Any, Dict, Union
+
+from stac_fastapi.core.extensions.filter import (
+    AdvancedComparisonNode,
+    AdvancedComparisonOp,
+    ComparisonNode,
+    ComparisonOp,
+    CqlNode,
+    LogicalNode,
+    LogicalOp,
+    SpatialNode,
+    SpatialOp,
+)
+
+
+def to_es_via_ast(
+    queryables_mapping: Dict[str, Any], query: Union[Dict[str, Any], CqlNode]
+) -> Dict[str, Any]:
+    """Transform CQL2 query to Elasticsearch/Opensearch query via AST."""
+    from .ast_parser import Cql2AstParser
+
+    if isinstance(query, CqlNode):
+        ast = query
+    else:
+        parser = Cql2AstParser(queryables_mapping)
+        ast = parser.parse(query)
+
+    result = _transform_ast_node(ast, queryables_mapping)
+    return result
+
+
+def _transform_ast_node(
+    node: Any, queryables_mapping: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Transform AST node to Elasticsearch/Opensearch query."""
+    if isinstance(node, LogicalNode):
+        bool_type = {
+            LogicalOp.AND: "must",
+            LogicalOp.OR: "should",
+            LogicalOp.NOT: "must_not",
+        }[node.op]
+
+        if node.op == LogicalOp.NOT:
+            return {
+                "bool": {
+                    bool_type: _transform_ast_node(node.children[0], queryables_mapping)
+                }
+            }
+        else:
+            return {
+                "bool": {
+                    bool_type: [
+                        _transform_ast_node(child, queryables_mapping)
+                        for child in node.children
+                    ]
+                }
+            }
+
+    elif isinstance(node, ComparisonNode):
+        field = _to_es_field(queryables_mapping, node.field)
+        value = node.value
+
+        if isinstance(value, dict) and "timestamp" in value:
+            value = value["timestamp"]
+
+        if node.op == ComparisonOp.EQ:
+            return {"term": {field: value}}
+        elif node.op == ComparisonOp.NEQ:
+            return {"bool": {"must_not": [{"term": {field: value}}]}}
+        elif node.op in [
+            ComparisonOp.LT,
+            ComparisonOp.LTE,
+            ComparisonOp.GT,
+            ComparisonOp.GTE,
+        ]:
+            range_op = {
+                ComparisonOp.LT: "lt",
+                ComparisonOp.LTE: "lte",
+                ComparisonOp.GT: "gt",
+                ComparisonOp.GTE: "gte",
+            }[node.op]
+            return {"range": {field: {range_op: value}}}
+        elif node.op == ComparisonOp.IS_NULL:
+            return {"bool": {"must_not": {"exists": {"field": field}}}}
+
+    elif isinstance(node, AdvancedComparisonNode):
+        field = _to_es_field(queryables_mapping, node.field)
+
+        if node.op == AdvancedComparisonOp.BETWEEN:
+            if isinstance(node.value, (list, tuple)) and len(node.value) == 2:
+                gte, lte = node.value[0], node.value[1]
+                if isinstance(gte, dict) and "timestamp" in gte:
+                    gte = gte["timestamp"]
+                if isinstance(lte, dict) and "timestamp" in lte:
+                    lte = lte["timestamp"]
+                return {"range": {field: {"gte": gte, "lte": lte}}}
+
+        elif node.op == AdvancedComparisonOp.IN:
+            if not isinstance(node.value, list):
+                raise ValueError(f"IN operator expects list, got {type(node.value)}")
+            return {"terms": {field: node.value}}
+
+        elif node.op == AdvancedComparisonOp.LIKE:
+            pattern = str(node.value)
+
+            es_pattern = ""
+            i = 0
+            while i < len(pattern):
+                if pattern[i] == "\\" and i + 1 < len(pattern):
+                    i += 1
+                    if pattern[i] == "%":
+                        es_pattern += "%"
+                    elif pattern[i] == "_":
+                        es_pattern += "_"
+                    elif pattern[i] == "\\":
+                        es_pattern += "\\"
+                    else:
+                        es_pattern += "\\" + pattern[i]
+                elif pattern[i] == "%":
+                    es_pattern += "*"
+                elif pattern[i] == "_":
+                    es_pattern += "?"
+                else:
+                    es_pattern += pattern[i]
+                i += 1
+
+            return {
+                "wildcard": {field: {"value": es_pattern, "case_insensitive": True}}
+            }
+
+    elif isinstance(node, SpatialNode):
+        field = _to_es_field(queryables_mapping, node.field)
+
+        relation_mapping = {
+            SpatialOp.S_INTERSECTS: "intersects",
+            SpatialOp.S_CONTAINS: "contains",
+            SpatialOp.S_WITHIN: "within",
+            SpatialOp.S_DISJOINT: "disjoint",
+        }
+
+        relation = relation_mapping[node.op]
+        return {"geo_shape": {field: {"shape": node.geometry, "relation": relation}}}
+
+    raise ValueError("Unsupported AST node")
+
+
+def _to_es_field(queryables_mapping: Dict[str, Any], field: str) -> str:
+    """Map field name using queryables mapping."""
+    return queryables_mapping.get(field, field)

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/cql2.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/cql2.py
@@ -1,6 +1,14 @@
 """CQL2 pattern conversion helpers for Elasticsearch/OpenSearch."""
 
 import re
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from stac_fastapi.core.datetime_utils import format_datetime_range
+from stac_fastapi.sfeos_helpers.mappings import ITEM_INDICES
+
+from .ast_parser import Cql2AstParser
+from .ast_transform import to_es_via_ast
+from .datetime_optimizer import DatetimeOptimizer, extract_collection_datetime
 
 cql2_like_patterns = re.compile(r"\\.|[%_]|\\$")
 valid_like_substitutions = {
@@ -37,3 +45,81 @@ def cql2_like_to_es(string: str) -> str:
         repl=_replace_like_patterns,
         string=string,
     )
+
+
+async def resolve_cql2_indexes(
+    cql2_metadata: List[Tuple[Union[str, List[str]], Optional[str]]],
+    index_selector,
+    apply_datetime_filter: Callable[[Any, str], Tuple[Any, Dict[str, Any]]],
+    search,
+) -> Tuple[str, List[str]]:
+    """Resolve indexes for CQL2 JSON queries for datetime and collection ids.
+
+    Args:
+        cql2_metadata: List of tuples containing metadata
+        index_selector: The index selector instance
+        apply_datetime_filter: Function to apply datetime on search
+        search: The search query object
+
+    Returns:
+        Comma-separated indexes, list of collection ids
+    """
+    all_collections = []
+    collection_index_map: Dict[str, List[str]] = {}
+
+    for collection_item, date_range in cql2_metadata:
+        collections = (
+            collection_item if isinstance(collection_item, list) else [collection_item]
+        )
+        all_collections.extend(collections)
+
+        if date_range:
+            _, collection_datetime = apply_datetime_filter(
+                search, format_datetime_range(date_str=date_range)
+            )
+            for collection in collections:
+                indexes = await index_selector.select_indexes(
+                    [collection], collection_datetime
+                )
+                index_list = [idx.strip() for idx in indexes.split(",") if idx.strip()]
+                collection_index_map.setdefault(collection, []).extend(index_list)
+
+    all_indexes = []
+    seen_indexes = set()
+
+    for collection in all_collections:
+        if collection in collection_index_map:
+            for idx in collection_index_map[collection]:
+                if idx not in seen_indexes:
+                    seen_indexes.add(idx)
+                    all_indexes.append(idx)
+
+    index_param = ",".join(all_indexes)
+    collection_ids = list(set(all_collections))
+
+    if not index_param:
+        return ITEM_INDICES, collection_ids
+
+    return index_param, collection_ids
+
+
+def build_cql2_filter(queryables_mapping: Dict, filter: Dict) -> Tuple[Dict, List]:
+    """Build query from CQL2 filter with metadata extraction.
+
+    Args:
+        queryables_mapping: Queryables mapping dictionary
+        filter: CQL2 JSON filter dictionary
+
+    Returns:
+        Tuple of es_query_dict, metadata
+    """
+    parser = Cql2AstParser(queryables_mapping)
+    ast = parser.parse(filter)
+
+    optimizer = DatetimeOptimizer()
+    optimized_ast = optimizer.optimize_query_structure(ast)
+
+    es_query = to_es_via_ast(queryables_mapping, optimized_ast)
+    metadata = extract_collection_datetime(optimized_ast)
+
+    return es_query, metadata

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/datetime_optimizer.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/datetime_optimizer.py
@@ -1,0 +1,229 @@
+"""Extracts datetime patterns from CQL2 AST."""
+
+from typing import Any, List, Tuple, Union
+
+from stac_fastapi.core.extensions.filter import (
+    AdvancedComparisonNode,
+    AdvancedComparisonOp,
+    ComparisonNode,
+    ComparisonOp,
+    CqlNode,
+    DateTimeExactNode,
+    DateTimeRangeNode,
+    LogicalNode,
+    LogicalOp,
+)
+
+
+class DatetimeOptimizer:
+    """Extract datetime from CQL2 AST."""
+
+    def __init__(self) -> None:
+        """Initialize the datetime optimizer."""
+        self.datetime_nodes: List[Union[DateTimeRangeNode, DateTimeExactNode]] = []
+
+    def extract_datetime_nodes(
+        self, node: CqlNode
+    ) -> List[Union[DateTimeRangeNode, DateTimeExactNode]]:
+        """Extract datetime nodes from AST."""
+        datetime_nodes = []
+
+        def _traverse(current: CqlNode):
+            if isinstance(current, ComparisonNode):
+                if self._is_datetime_field(current.field):
+                    if current.op == ComparisonOp.EQ:
+                        datetime_nodes.append(
+                            DateTimeExactNode(field=current.field, value=current.value)
+                        )
+                    elif current.op == ComparisonOp.GTE:
+                        datetime_nodes.append(
+                            DateTimeRangeNode(field=current.field, start=current.value)
+                        )
+                    elif current.op == ComparisonOp.LTE:
+                        datetime_nodes.append(
+                            DateTimeRangeNode(field=current.field, end=current.value)
+                        )
+
+            elif isinstance(current, AdvancedComparisonNode):
+                if (
+                    current.op == AdvancedComparisonOp.BETWEEN
+                    and self._is_datetime_field(current.field)
+                ):
+                    if (
+                        isinstance(current.value, (list, tuple))
+                        and len(current.value) == 2
+                    ):
+                        datetime_nodes.append(
+                            DateTimeRangeNode(
+                                field=current.field,
+                                start=current.value[0],
+                                end=current.value[1],
+                            )
+                        )
+
+            if isinstance(current, LogicalNode):
+                for child in current.children:
+                    _traverse(child)
+
+        _traverse(node)
+        return datetime_nodes
+
+    def _is_datetime_field(self, field: str) -> bool:
+        """Datetime field checker."""
+        field_lower = field.lower()
+        return any(
+            dt_field in field_lower
+            for dt_field in ["datetime", "start_datetime", "end_datetime"]
+        )
+
+    def optimize_query_structure(self, ast: CqlNode) -> CqlNode:
+        """Optimize AST structure for better query performance."""
+        return self._reorder_for_datetime_priority(ast)
+
+    def _reorder_for_datetime_priority(self, node: CqlNode) -> CqlNode:
+        """Reorder query tree to prioritize datetime filters."""
+        if isinstance(node, LogicalNode):
+            if node.op == LogicalOp.AND:
+                datetime_children = []
+                other_children = []
+
+                for child in node.children:
+                    processed_child = self._reorder_for_datetime_priority(child)
+                    if self._contains_datetime(processed_child):
+                        datetime_children.append(processed_child)
+                    else:
+                        other_children.append(processed_child)
+
+                reordered_children = datetime_children + other_children
+
+                if len(reordered_children) == 1:
+                    return reordered_children[0]
+
+                return LogicalNode(op=LogicalOp.AND, children=reordered_children)
+
+            elif node.op in [LogicalOp.OR, LogicalOp.NOT]:
+                processed_children = [
+                    self._reorder_for_datetime_priority(child)
+                    for child in node.children
+                ]
+                return LogicalNode(op=node.op, children=processed_children)
+
+        return node
+
+    def _contains_datetime(self, node: CqlNode) -> bool:
+        """Check if node contains datetime filter."""
+        if isinstance(node, (ComparisonNode, AdvancedComparisonNode)):
+            return self._is_datetime_field(node.field)
+
+        elif isinstance(node, LogicalNode):
+            return any(self._contains_datetime(child) for child in node.children)
+
+        return False
+
+
+def extract_from_ast(node: CqlNode, field_name: str) -> List[Any]:
+    """Extract all values for a specific field from a CQL AST."""
+    values = []
+
+    def recurse(n: CqlNode):
+        """Recursively traverse AST nodes to extract field values."""
+        if isinstance(n, LogicalNode):
+            for child in n.children:
+                recurse(child)
+            if n.op == LogicalOp.AND:
+                datetime_nodes: List[ComparisonNode] = []
+                for child in n.children:
+                    if isinstance(child, ComparisonNode) and child.field == "datetime":
+                        datetime_nodes.append(child)
+
+                if len(datetime_nodes) == 2:
+                    gte_node = None
+                    lte_node = None
+                    for d_node in datetime_nodes:
+                        if d_node.op == ComparisonOp.GTE:
+                            gte_node = d_node
+                        elif d_node.op == ComparisonOp.LTE:
+                            lte_node = d_node
+
+                    if gte_node and lte_node:
+                        values.append(
+                            {
+                                "type": "range",
+                                "start": gte_node.value,
+                                "end": lte_node.value,
+                            }
+                        )
+        elif isinstance(n, ComparisonNode):
+            if n.field == field_name:
+                if isinstance(n.value, list):
+                    values.extend(n.value)
+                else:
+                    values.append(n.value)
+
+        elif isinstance(n, AdvancedComparisonNode):
+            if n.field == field_name:
+                if isinstance(n.value, list):
+                    values.extend(n.value)
+                else:
+                    values.append(n.value)
+
+    recurse(node)
+    return values if values else None
+
+
+def extract_collection_datetime(node: CqlNode) -> List[Tuple[List[str], str]]:
+    """Extract collections, datetime range from CQL AST.
+
+    Returns:
+        List of tuples where each tuple contains:
+        - collections: List[str] collection id(s)
+        - datetime_range: str or empty string if no datetime constraint
+    """
+    pairs = []
+
+    def recurse(n: CqlNode):
+        if isinstance(n, LogicalNode) and n.op == LogicalOp.AND:
+            collections: List[str] = []
+            gte_date = None
+            lte_date = None
+
+            for child in n.children:
+                if isinstance(child, (ComparisonNode, AdvancedComparisonNode)):
+                    if child.field == "collection":
+                        if isinstance(child.value, list):
+                            collections.extend(child.value)
+                        else:
+                            collections.append(child.value)
+                    elif child.field in ["datetime", "start_datetime", "end_datetime"]:
+                        if isinstance(child, ComparisonNode):
+                            if child.op == ComparisonOp.GTE:
+                                gte_date = child.value
+                            elif child.op == ComparisonOp.LTE:
+                                lte_date = child.value
+                        elif isinstance(child, AdvancedComparisonNode):
+                            if child.op == AdvancedComparisonOp.BETWEEN:
+                                if (
+                                    isinstance(child.value, (list, tuple))
+                                    and len(child.value) == 2
+                                ):
+                                    gte_date = child.value[0]
+                                    lte_date = child.value[1]
+
+            if gte_date or lte_date:
+                if gte_date and lte_date:
+                    date_range = f"{gte_date}/{lte_date}"
+                elif gte_date:
+                    date_range = f"{gte_date}/.."
+                elif lte_date:
+                    date_range = f"../{lte_date}"
+                else:
+                    date_range = ""
+                pairs.append((collections, date_range))
+            elif collections:
+                pairs.append((collections, ""))
+        if isinstance(n, LogicalNode):
+            for child in n.children:
+                recurse(child)
+
+    recurse(node)
+    return pairs

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/inserters.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/inserters.py
@@ -256,11 +256,11 @@ class DatetimeIndexInserter(BaseIndexInserter):
                 datetime=str(
                     extract_date(latest_item["_source"]["properties"]["datetime"])
                 ),
-                end_datetime=str(
-                    extract_first_date_from_index(aliases_dict["end_datetime"])
-                )
-                if aliases_dict.get("end_datetime")
-                else None,
+                end_datetime=(
+                    str(extract_first_date_from_index(aliases_dict["end_datetime"]))
+                    if aliases_dict.get("end_datetime")
+                    else None
+                ),
             )
 
             await self.datetime_manager.handle_oversized_index(

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/managers.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/managers.py
@@ -211,15 +211,21 @@ class DatetimeIndexManager:
             str: Created datetime index name.
         """
         index_params = {
-            "start_datetime": str(extract_date(product_datetimes.start_datetime))
-            if primary_datetime_name == "start_datetime"
-            else None,
-            "datetime": str(extract_date(product_datetimes.datetime))
-            if primary_datetime_name == "datetime"
-            else None,
-            "end_datetime": str(extract_date(product_datetimes.end_datetime))
-            if primary_datetime_name == "start_datetime"
-            else None,
+            "start_datetime": (
+                str(extract_date(product_datetimes.start_datetime))
+                if primary_datetime_name == "start_datetime"
+                else None
+            ),
+            "datetime": (
+                str(extract_date(product_datetimes.datetime))
+                if primary_datetime_name == "datetime"
+                else None
+            ),
+            "end_datetime": (
+                str(extract_date(product_datetimes.end_datetime))
+                if primary_datetime_name == "start_datetime"
+                else None
+            ),
         }
 
         target_index = await self.index_operations.create_datetime_index(

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/selection/selectors.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/selection/selectors.py
@@ -1,4 +1,5 @@
 """Async index selectors with datetime-based filtering."""
+
 from typing import Any, Dict, List, Optional, Tuple
 
 from stac_fastapi.core.utilities import get_bool_env

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
@@ -1,2 +1,3 @@
 """library version."""
+
 __version__ = "6.10.1"

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -1166,6 +1166,208 @@ async def test_search_datetime_with_null_datetime(
 
 
 @pytest.mark.asyncio
+async def test_search_cql2_json_datetime_operators(app_client, ctx):
+    """Test POST /search with CQL2 json datetime filter operators"""
+
+    test_item = ctx.item
+    item_datetime = test_item["properties"]["datetime"]
+
+    cql2_equal = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": "=", "args": [{"property": "datetime"}, item_datetime]},
+    }
+    resp = await app_client.post("/search", json=cql2_equal)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    later_datetime = "2020-02-13T12:30:22Z"
+    cql2_lte = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": "<=", "args": [{"property": "datetime"}, later_datetime]},
+    }
+    resp = await app_client.post("/search", json=cql2_lte)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    earlier_datetime = "2020-02-11T12:30:22Z"
+    cql2_gte = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": ">=", "args": [{"property": "datetime"}, earlier_datetime]},
+    }
+    resp = await app_client.post("/search", json=cql2_gte)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    range_start = "2020-02-12T00:00:00Z"
+    range_end = "2020-02-13T00:00:00Z"
+    cql2_between = {
+        "filter-lang": "cql2-json",
+        "filter": {
+            "op": "and",
+            "args": [
+                {"op": ">=", "args": [{"property": "datetime"}, range_start]},
+                {"op": "<=", "args": [{"property": "datetime"}, range_end]},
+            ],
+        },
+    }
+    resp = await app_client.post("/search", json=cql2_between)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+
+@pytest.mark.asyncio
+async def test_search_cql2_json_start_end_datetime_operators(app_client, ctx):
+    """Test POST /search with CQL2 json start_datetime, end_datetime filter operators"""
+
+    test_item = ctx.item
+    start_datetime = test_item["properties"]["start_datetime"]
+    end_datetime = test_item["properties"]["end_datetime"]
+
+    cql2_start_equal = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": "=", "args": [{"property": "start_datetime"}, start_datetime]},
+    }
+    resp = await app_client.post("/search", json=cql2_start_equal)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    later_start = "2020-02-09T12:30:22Z"
+    cql2_start_lte = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": "<=", "args": [{"property": "start_datetime"}, later_start]},
+    }
+    resp = await app_client.post("/search", json=cql2_start_lte)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    earlier_start = "2020-02-07T12:30:22Z"
+    cql2_start_gte = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": ">=", "args": [{"property": "start_datetime"}, earlier_start]},
+    }
+    resp = await app_client.post("/search", json=cql2_start_gte)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    start_range_start = "2020-02-08T00:00:00Z"
+    start_range_end = "2020-02-09T00:00:00Z"
+    cql2_start_between = {
+        "filter-lang": "cql2-json",
+        "filter": {
+            "op": "and",
+            "args": [
+                {
+                    "op": ">=",
+                    "args": [{"property": "start_datetime"}, start_range_start],
+                },
+                {"op": "<=", "args": [{"property": "start_datetime"}, start_range_end]},
+            ],
+        },
+    }
+    resp = await app_client.post("/search", json=cql2_start_between)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    cql2_end_equal = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": "=", "args": [{"property": "end_datetime"}, end_datetime]},
+    }
+    resp = await app_client.post("/search", json=cql2_end_equal)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    later_end = "2020-02-17T12:30:22Z"
+    cql2_end_lte = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": "<=", "args": [{"property": "end_datetime"}, later_end]},
+    }
+    resp = await app_client.post("/search", json=cql2_end_lte)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    earlier_end = "2020-02-15T12:30:22Z"
+    cql2_end_gte = {
+        "filter-lang": "cql2-json",
+        "filter": {"op": ">=", "args": [{"property": "end_datetime"}, earlier_end]},
+    }
+    resp = await app_client.post("/search", json=cql2_end_gte)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    end_range_start = "2020-02-16T00:00:00Z"
+    end_range_end = "2020-02-17T00:00:00Z"
+    cql2_end_between = {
+        "filter-lang": "cql2-json",
+        "filter": {
+            "op": "and",
+            "args": [
+                {"op": ">=", "args": [{"property": "end_datetime"}, end_range_start]},
+                {"op": "<=", "args": [{"property": "end_datetime"}, end_range_end]},
+            ],
+        },
+    }
+    resp = await app_client.post("/search", json=cql2_end_between)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+    cql2_start_end_range = {
+        "filter-lang": "cql2-json",
+        "filter": {
+            "op": "and",
+            "args": [
+                {
+                    "op": ">=",
+                    "args": [{"property": "start_datetime"}, "2020-02-07T12:30:22Z"],
+                },
+                {
+                    "op": "<=",
+                    "args": [{"property": "end_datetime"}, "2020-02-17T12:30:22Z"],
+                },
+            ],
+        },
+    }
+    resp = await app_client.post("/search", json=cql2_start_end_range)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["id"] == test_item["id"]
+
+
+@pytest.mark.asyncio
+async def test_select_indexes(txn_client, load_test_data):
+    """Run select_indexes test."""
+
+    database = txn_client.database
+    index_selector = database.async_index_selector
+
+    collection = load_test_data("test_collection.json")
+    collection_id = "test-collection-1"
+    collection["id"] = collection_id
+
+    test_item = load_test_data("test_item.json")
+    test_item["id"] = "test-item-1"
+
+    result = await index_selector.select_indexes(
+        ["test-collection-1"],
+        {"gte": "2024-01-01T00:00:00Z", "lte": "2024-12-31T23:59:59Z"},
+    )
+
+    assert result is not None
+    assert result == "items_test-collection-1"
+
+
+@pytest.mark.asyncio
 async def test_hidden_item_true(app_client, txn_client, load_test_data):
     """Test item with hidden=true is filtered out."""
 


### PR DESCRIPTION
This PR implements a CQL2 Abstract Syntax Tree (AST) structure for CQL2 Filters to enable better parameter access for index selection in search queries: 
- Introduces a structured AST representation of CQL2 queries (replacing dict-based processing)
- Adds datetime extraction logic to easily identify and access datetime parameters
- Provides ability for selecting appropriate indexes such as datetime, start_datetime, end_datetime
The AST-based approach makes it easier to parse CQL2 filters, particularly for identifying datetime constraints (datetime, start_datetime, end_datetime) to optimize search performance through proper index selection.

Examples of AST nodes:
AND:
```
LogicalNode(op=<LogicalOp.AND: 'and'>, children=[ComparisonNode(op=<ComparisonOp.EQ: '='>, field='collection', value='landsat-8-l1'), 
                                                 ComparisonNode(op=<ComparisonOp.GT: '>'>, field='properties.cloud_cover', value=50)])
```

OR:
```
LogicalNode(op=<LogicalOp.OR: 'or'>, children=[ComparisonNode(op=<ComparisonOp.EQ: '='>, field='properties.platform', value='landsat-8'), 
                                               ComparisonNode(op=<ComparisonOp.EQ: '='>, field='properties.platform', value='sentinel-2')])
```

NOT:
```
LogicalNode(op=<LogicalOp.NOT: 'not'>, children=[ComparisonNode(op=<ComparisonOp.EQ: '='>, field='properties.cloud_cover', value=0)])
```

EQ (=):
```
ComparisonNode(op=<ComparisonOp.EQ: '='>, field='properties.cloud_cover', value=20)
```

NEQ (<>)
```
ComparisonNode(op=<ComparisonOp.NEQ: '<>'>, field='properties.platform', value='landsat-8')
```

LT (<)
```
ComparisonNode(op=<ComparisonOp.LT: '<'>, field='properties.cloud_cover', value=30)
```

LTE (<=)
```
ComparisonNode(op=<ComparisonOp.LTE: '<='>, field='properties.cloud_cover', value=50)
```

GT (>)
```
ComparisonNode(op=<ComparisonOp.GT: '>'>, field='properties.gsd', value=10)
```

GTE (>=)
```
ComparisonNode(op=<ComparisonOp.GTE: '>='>, field='properties.cloud_cover', value=0)
```

IS_NULL
```
ComparisonNode(op=<ComparisonOp.IS_NULL: 'isNull'>, field='properties.cloud_cover', value=None)
```

LIKE
```
AdvancedComparisonNode(op=<AdvancedComparisonOp.LIKE: 'like'>, field='id', value='LC08%')
```

BETWEEN
```
AdvancedComparisonNode(op=<AdvancedComparisonOp.BETWEEN: 'between'>, field='properties.cloud_cover', value=(10, 50))
```

IN
```
AdvancedComparisonNode(op=<AdvancedComparisonOp.IN: 'in'>, field='properties.platform', value=['landsat-8', 'sentinel-2', 'modis'])
```

S_INTERSECTS
```
SpatialNode(op=<SpatialOp.S_INTERSECTS: 's_intersects'>, field='geometry', geometry={'type': 'Polygon', 'coordinates': [[[-110, 40], [-110, 41], [-109, 41], [-109, 40], [-110, 40]]]})
```

S_CONTAINS
```
SpatialNode(op=<SpatialOp.S_CONTAINS: 's_contains'>, field='geometry', geometry={'type': 'Point', 'coordinates': [-110.5, 40.5]})
```

S_WITHIN
```
SpatialNode(op=<SpatialOp.S_WITHIN: 's_within'>, field='geometry', geometry={'type': 'Polygon', 'coordinates': [[[-120, 35], [-120, 45], [-100, 45], [-100, 35], [-120, 35]]]})
```

S_DISJOINT
```
SpatialNode(op=<SpatialOp.S_DISJOINT: 's_disjoint'>, field='geometry', geometry={'type': 'Polygon', 'coordinates': [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]]})
```

DateTimeRange
```
LogicalNode(op=<LogicalOp.AND: 'and'>, children=[ComparisonNode(op=<ComparisonOp.GTE: '>='>, field='properties.datetime', value='2024-01-01T00:00:00Z'), 
                                                 ComparisonNode(op=<ComparisonOp.LTE: '<='>, field='properties.datetime', value='2024-12-31T23:59:59Z')])
```

DateTimeExactNode
```
ComparisonNode(op=<ComparisonOp.EQ: '='>, field='properties.datetime', value='2024-06-15T10:30:00Z')
```

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog