### PR TITLE
Modify retry strategies to avoid state mutation

### DIFF
--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/utils.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/utils.py
@@ -534,7 +534,7 @@ def retry_on_datetime_not_found(func) -> Callable:
             isinstance(self.async_index_inserter, DatetimeIndexInserter)
             and datetime_search
         ):
-            async for attempt in DATETIME_RETRY_STRATEGY:
+            async for attempt in DATETIME_RETRY_STRATEGY.copy():
                 with attempt:
                     if attempt.retry_state.attempt_number > 1:
                         await self.async_index_inserter.refresh_cache()


### PR DESCRIPTION
Concurrency Fix (.copy()): Added .copy() to the retry strategies in the async for loops. Because we defined these strategies as global constants, concurrent API requests would share the same object and overwrite each other's retry counters! Calling .copy() creates a fresh, thread-safe state for every request.

Performance Guard (attempt_number > 1): Wrapped refresh_cache() in an if attempt.retry_state.attempt_number > 1: condition. Without this, the loop executes the cache refresh on the first attempt of every single normal datetime search, completely defeating the purpose of our cache. This guard ensures we only take the database hit during an actual retry.