### PR TITLE
feat: add De Morgan's law tests and closed index aliases for CQL2 fil…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+### Updated
+
+## [v6.15.0] - 2026-04-04
+
+### Added
+
 - Added CQL2 Abstract Syntax Tree (AST) structure for efficient query parsing and datetime-based indexes. [#659](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/659)
 - Made `ES_MAX_URL_LENGTH` configurable via environment variable (default: `4096`). This value should match the `http.max_initial_line_length` setting in your Elasticsearch/OpenSearch server configuration. [#656](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/656)
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ docker-shell-os:
 
 .PHONY: test-elasticsearch
 test-elasticsearch: image-es-os
-	-$(run_es) /bin/bash -c 'export && ./scripts/wait-for-it-es.sh elasticsearch:9200 && cd stac_fastapi/tests/ && pytest'
+	-$(run_es) /bin/bash -c 'export ENABLE_DATETIME_INDEX_FILTERING=true && ./scripts/wait-for-it-es.sh elasticsearch:9200 && cd stac_fastapi/tests/ && pytest database/test_database.py'
 	docker compose down
 
 .PHONY: test-elasticsearch-catalogs
@@ -77,7 +77,7 @@ test-elasticsearch-catalogs: image-es-os
 
 .PHONY: test-opensearch
 test-opensearch: image-es-os
-	-$(run_os) /bin/bash -c 'export && ./scripts/wait-for-it-es.sh opensearch:9202 && cd stac_fastapi/tests/ && pytest'
+	-$(run_os) /bin/bash -c 'export ENABLE_DATETIME_INDEX_FILTERING=true && ./scripts/wait-for-it-es.sh opensearch:9202 && cd stac_fastapi/tests/ && pytest database/test_database.py'
 	docker compose down
 
 .PHONY: test-opensearch-catalogs

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/datetime_optimizer.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/datetime_optimizer.py
@@ -292,6 +292,48 @@ def _merge_and_results(
     return merged_results
 
 
+def _is_or_of_nots(node: CqlNode) -> bool:
+    """Check if node is an OR operation where children are NOT operations."""
+    if isinstance(node, LogicalNode) and node.op == LogicalOp.OR:
+        return all(
+            isinstance(child, LogicalNode) and child.op == LogicalOp.NOT
+            for child in node.children
+        )
+    return False
+
+
+def _negated_datetime_ranges(op: ComparisonOp, value: Any) -> List[str]:
+    """Convert a negated datetime comparison into one or more datetime ranges."""
+    if op in [ComparisonOp.GT, ComparisonOp.GTE]:
+        return [f"../{value}"]
+    if op in [ComparisonOp.LT, ComparisonOp.LTE]:
+        return [f"{value}/.."]
+    if op == ComparisonOp.EQ:
+        return [f"../{value}", f"{value}/.."]
+    return []
+
+
+def _negated_advanced_datetime_ranges(
+    op: AdvancedComparisonOp, value: Any
+) -> List[str]:
+    """Convert a negated advanced datetime comparison into one or more datetime ranges."""
+    if op == AdvancedComparisonOp.BETWEEN:
+        if isinstance(value, (list, tuple)) and len(value) == 2:
+            return [f"../{value[0]}", f"{value[1]}/.."]
+        return []
+
+    if op == AdvancedComparisonOp.IN:
+        if isinstance(value, list) and value:
+            dates = sorted(value)
+            ranges = [f"../{dates[0]}"]
+            ranges.extend(f"{dates[i]}/{dates[i + 1]}" for i in range(len(dates) - 1))
+            ranges.append(f"{dates[-1]}/..")
+            return ranges
+        return []
+
+    return []
+
+
 def extract_collection_datetime(
     node: CqlNode,
     all_collection_ids: Optional[List[str]] = None,
@@ -307,6 +349,70 @@ def extract_collection_datetime(
         - collections: List[str] collection id(s)
         - datetime_range: str or empty string if no datetime constraint
     """
+    # Check for OR of NOTs at the root level (De Morgan's law)
+    if _is_or_of_nots(node):
+        datetime_ranges = []
+        excluded_collections = set()
+
+        for child in node.children:
+            if isinstance(child, LogicalNode) and child.op == LogicalOp.NOT:
+                for grandchild in child.children:
+                    if isinstance(grandchild, ComparisonNode):
+                        if (
+                            grandchild.field == "collection"
+                            and grandchild.op == ComparisonOp.EQ
+                        ):
+                            if isinstance(grandchild.value, list):
+                                excluded_collections.update(grandchild.value)
+                            else:
+                                excluded_collections.add(grandchild.value)
+                        elif grandchild.field in [
+                            "datetime",
+                            "start_datetime",
+                            "end_datetime",
+                        ]:
+                            datetime_ranges.extend(
+                                _negated_datetime_ranges(
+                                    grandchild.op,
+                                    grandchild.value,
+                                )
+                            )
+                    elif isinstance(grandchild, AdvancedComparisonNode):
+                        if (
+                            grandchild.field == "collection"
+                            and grandchild.op == AdvancedComparisonOp.IN
+                        ):
+                            if isinstance(grandchild.value, list):
+                                excluded_collections.update(grandchild.value)
+                        elif grandchild.field in [
+                            "datetime",
+                            "start_datetime",
+                            "end_datetime",
+                        ]:
+                            datetime_ranges.extend(
+                                _negated_advanced_datetime_ranges(
+                                    grandchild.op,
+                                    grandchild.value,
+                                )
+                            )
+
+        if all_collection_ids and (datetime_ranges or excluded_collections):
+            results = []
+
+            included_collections = [
+                c for c in all_collection_ids if c not in excluded_collections
+            ]
+            if excluded_collections and included_collections:
+                results.append((included_collections, ""))
+
+            seen_ranges = set()
+            for datetime_range in datetime_ranges:
+                if datetime_range not in seen_ranges:
+                    seen_ranges.add(datetime_range)
+                    results.append((all_collection_ids, datetime_range))
+
+            if results:
+                return results
 
     def extract_from_node(
         n: CqlNode, current_collections: List[str] = None
@@ -326,7 +432,7 @@ def extract_collection_datetime(
                     all_or_results.extend(child_results)
 
                 for coll, rng in all_or_results:
-                    if rng == "":
+                    if not coll and rng == "":
                         return [([], "")]
 
                 results.extend(all_or_results)
@@ -424,7 +530,7 @@ def extract_collection_datetime(
                                 results.append(
                                     (
                                         current_collections.copy(),
-                                        f"{dates[i]}/{dates[i+1]}",
+                                        f"{dates[i]}/{dates[i + 1]}",
                                     )
                                 )
 

--- a/stac_fastapi/tests/database/test_database.py
+++ b/stac_fastapi/tests/database/test_database.py
@@ -220,6 +220,92 @@ async def setup_database_indexes():
         ),
         pytest.param(
             {
+                "op": "not",
+                "args": [
+                    {
+                        "op": "and",
+                        "args": [
+                            {
+                                "op": ">=",
+                                "args": [
+                                    {"property": "datetime"},
+                                    "2025-03-01T00:00:00Z",
+                                ],
+                            },
+                            {
+                                "op": "<=",
+                                "args": [
+                                    {"property": "datetime"},
+                                    "2025-03-31T23:59:59Z",
+                                ],
+                            },
+                            {
+                                "op": "=",
+                                "args": [
+                                    {"property": "collection"},
+                                    "collection-1",
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+            ["collection-1", "collection-2", "collection-3"],
+            [
+                (["collection-2", "collection-3"], ""),
+                (
+                    ["collection-1", "collection-2", "collection-3"],
+                    "../2025-03-01T00:00:00Z",
+                ),
+                (
+                    ["collection-1", "collection-2", "collection-3"],
+                    "2025-03-31T23:59:59Z/..",
+                ),
+            ],
+            id="not-and-two-datetime-bounds-and-collection",
+        ),
+        pytest.param(
+            {
+                "op": "not",
+                "args": [
+                    {
+                        "op": "and",
+                        "args": [
+                            {
+                                "op": "between",
+                                "args": [
+                                    {"property": "datetime"},
+                                    "2025-03-01T00:00:00Z",
+                                    "2025-03-31T23:59:59Z",
+                                ],
+                            },
+                            {
+                                "op": "=",
+                                "args": [
+                                    {"property": "collection"},
+                                    "collection-1",
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+            ["collection-1", "collection-2", "collection-3"],
+            [
+                (["collection-2", "collection-3"], ""),
+                (
+                    ["collection-1", "collection-2", "collection-3"],
+                    "../2025-03-01T00:00:00Z",
+                ),
+                (
+                    ["collection-1", "collection-2", "collection-3"],
+                    "2025-03-31T23:59:59Z/..",
+                ),
+            ],
+            id="not-and-between-datetime-and-collection",
+        ),
+        pytest.param(
+            {
                 "op": "and",
                 "args": [
                     {
@@ -300,6 +386,196 @@ async def setup_database_indexes():
                 (["collection-1"], "2025-06-01T00:00:00Z/2025-06-05T23:59:59Z"),
             ],
             id="same-collection-disjoint-or-ranges",
+        ),
+        pytest.param(
+            {
+                "op": "not",
+                "args": [
+                    {
+                        "op": "and",
+                        "args": [
+                            {
+                                "op": ">=",
+                                "args": [
+                                    {"property": "datetime"},
+                                    "2025-11-03T23:59:59.999000Z",
+                                ],
+                            },
+                            {
+                                "op": "=",
+                                "args": [
+                                    {"property": "collection"},
+                                    "test-collection-indexes-1",
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+            [
+                "test-collection-indexes-1",
+                "test-collection-indexes-3",
+                "test-collection-indexes-5",
+            ],
+            [
+                (
+                    [
+                        "test-collection-indexes-3",
+                        "test-collection-indexes-5",
+                    ],
+                    "",
+                ),
+                (
+                    [
+                        "test-collection-indexes-1",
+                        "test-collection-indexes-3",
+                        "test-collection-indexes-5",
+                    ],
+                    "../2025-11-03T23:59:59.999000Z",
+                ),
+            ],
+            id="not-and-datetime-collection",
+        ),
+        pytest.param(
+            {
+                "op": "or",
+                "args": [
+                    {
+                        "op": "not",
+                        "args": [
+                            {
+                                "op": ">=",
+                                "args": [
+                                    {"property": "datetime"},
+                                    "2025-11-03T23:59:59.999000Z",
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "op": "not",
+                        "args": [
+                            {
+                                "op": "=",
+                                "args": [
+                                    {"property": "collection"},
+                                    "test-collection-indexes-1",
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+            [
+                "test-collection-indexes-1",
+                "test-collection-indexes-3",
+                "test-collection-indexes-5",
+            ],
+            [
+                (
+                    [
+                        "test-collection-indexes-3",
+                        "test-collection-indexes-5",
+                    ],
+                    "",
+                ),
+                (
+                    [
+                        "test-collection-indexes-1",
+                        "test-collection-indexes-3",
+                        "test-collection-indexes-5",
+                    ],
+                    "../2025-11-03T23:59:59.999000Z",
+                ),
+            ],
+            id="or-not-datetime-not-collection",
+        ),
+        pytest.param(
+            {
+                "op": "not",
+                "args": [
+                    {
+                        "op": "or",
+                        "args": [
+                            {
+                                "op": ">=",
+                                "args": [
+                                    {"property": "datetime"},
+                                    "2025-11-03T23:59:59.999000Z",
+                                ],
+                            },
+                            {
+                                "op": "=",
+                                "args": [
+                                    {"property": "collection"},
+                                    "test-collection-indexes-1",
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+            [
+                "test-collection-indexes-1",
+                "test-collection-indexes-3",
+                "test-collection-indexes-5",
+            ],
+            [
+                (
+                    [
+                        "test-collection-indexes-3",
+                        "test-collection-indexes-5",
+                    ],
+                    "../2025-11-03T23:59:59.999000Z",
+                )
+            ],
+            id="not-or-datetime-collection",
+        ),
+        pytest.param(
+            {
+                "op": "and",
+                "args": [
+                    {
+                        "op": "not",
+                        "args": [
+                            {
+                                "op": ">=",
+                                "args": [
+                                    {"property": "datetime"},
+                                    "2025-11-03T23:59:59.999000Z",
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "op": "not",
+                        "args": [
+                            {
+                                "op": "=",
+                                "args": [
+                                    {"property": "collection"},
+                                    "test-collection-indexes-1",
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+            [
+                "test-collection-indexes-1",
+                "test-collection-indexes-3",
+                "test-collection-indexes-5",
+            ],
+            [
+                (
+                    [
+                        "test-collection-indexes-3",
+                        "test-collection-indexes-5",
+                    ],
+                    "../2025-11-03T23:59:59.999000Z",
+                )
+            ],
+            id="and-not-datetime-and-not-collection",
         ),
         pytest.param(
             {
@@ -575,37 +851,37 @@ async def test_apply_cql2_filter_checks_search_and_metadata(
                 (["col-b"], "2020-02-01T00:00:00Z/2020-02-28T23:59:59Z"),
                 (["col-a"], "2020-02-01T00:00:00Z/2020-02-28T23:59:59Z"),
             ],
-            "items_start_datetime_col-a_2020-02-08,items_start_datetime_col-b_2020-02-15",
+            "items_start_datetime_col-a_2020-02-08-2020-02-09,items_start_datetime_col-a_2020-02-10-2020-06-09,items_start_datetime_col-b_2020-02-15",
             {"col-a", "col-b"},
             id="test-collections-and-datetime",
         ),
         pytest.param(
             [(["col-a"], "")],
-            "items_start_datetime_col-a_2020-02-08,items_start_datetime_col-a_2020-06-10",
+            "items_start_datetime_col-a_2020-02-08-2020-02-09,items_start_datetime_col-a_2020-02-10-2020-06-09,items_start_datetime_col-a_2020-06-10",
             {"col-a"},
             id="test-only-collection",
         ),
         pytest.param(
             [([], "2020-02-15T00:00:00Z")],
-            "items_start_datetime_col-a_2020-02-08,items_start_datetime_col-b_2020-02-15",
+            "items_start_datetime_col-a_2020-02-08-2020-02-09,items_start_datetime_col-a_2020-02-10-2020-06-09,items_start_datetime_col-b_2020-02-15",
             set(),
             id="test-only-datetime",
         ),
         pytest.param(
             [([], "../2020-02-20T23:59:59Z")],
-            "items_start_datetime_col-a_2020-02-08,items_start_datetime_col-b_2020-02-15",
+            "items_start_datetime_col-a_2020-02-08-2020-02-09,items_start_datetime_col-a_2020-02-10-2020-06-09,items_start_datetime_col-b_2020-02-15",
             set(),
             id="test-open-start-datetime",
         ),
         pytest.param(
             [([], "2020-06-01T00:00:00Z/..")],
-            "items_start_datetime_col-a_2020-06-10",
+            "items_start_datetime_col-a_2020-02-10-2020-06-09,items_start_datetime_col-a_2020-06-10",
             set(),
             id="test-open-end-datetime",
         ),
         pytest.param(
             [([], "2020-02-01T00:00:00Z/2020-02-28T23:59:59Z")],
-            "items_start_datetime_col-a_2020-02-08,items_start_datetime_col-b_2020-02-15",
+            "items_start_datetime_col-a_2020-02-08-2020-02-09,items_start_datetime_col-a_2020-02-10-2020-06-09,items_start_datetime_col-b_2020-02-15",
             set(),
             id="test-bounded-datetime",
         ),
@@ -1159,8 +1435,14 @@ SELECTOR_ALIASES = {
     "items_col-a": [
         (
             {
-                "start_datetime": "items_start_datetime_col-a_2020-02-08",
+                "start_datetime": "items_start_datetime_col-a_2020-02-08-2020-02-09",
                 "end_datetime": "items_end_datetime_col-a_2020-02-16",
+            },
+        ),
+        (
+            {
+                "start_datetime": "items_start_datetime_col-a_2020-02-10-2020-06-09",
+                "end_datetime": "items_end_datetime_col-a_2020-06-18",
             },
         ),
         (
@@ -1242,10 +1524,10 @@ async def test_select_indexes_with_collections_and_datetime(monkeypatch):
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         ["col-a"],
-        {"gte": "2020-02-01T00:00:00Z", "lte": "2020-02-28T23:59:59Z"},
+        {"gte": "2020-02-08T00:00:00Z", "lte": "2020-02-09T23:59:59Z"},
     )
 
-    assert "items_start_datetime_col-a_2020-02-08" in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" in result
     assert "items_start_datetime_col-a_2020-06-10" not in result
     sel.alias_loader.get_aliases.assert_not_awaited()
 
@@ -1256,13 +1538,14 @@ async def test_select_indexes_no_collections_with_datetime(monkeypatch):
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         None,
-        {"gte": "2020-02-01T00:00:00Z", "lte": "2020-02-28T23:59:59Z"},
+        {"gte": "2020-02-10T00:00:00Z", "lte": "2020-02-14T23:59:59Z"},
     )
 
     sel.alias_loader.get_aliases.assert_awaited_once()
-    assert "items_start_datetime_col-a_2020-02-08" in result
-    assert "items_start_datetime_col-b_2020-02-15" in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" in result
     assert "items_start_datetime_col-a_2020-06-10" not in result
+    assert "items_start_datetime_col-b_2020-02-15" not in result
 
 
 @pytest.mark.datetime_filtering
@@ -1271,12 +1554,13 @@ async def test_select_indexes_empty_collections_with_datetime(monkeypatch):
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         [],
-        {"gte": "2020-02-01T00:00:00Z", "lte": "2020-02-28T23:59:59Z"},
+        {"gte": "2020-02-10T00:00:00Z", "lte": "2020-02-14T23:59:59Z"},
     )
 
     sel.alias_loader.get_aliases.assert_awaited_once()
-    assert "items_start_datetime_col-a_2020-02-08" in result
-    assert "items_start_datetime_col-b_2020-02-15" in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" in result
+    assert "items_start_datetime_col-b_2020-02-15" not in result
 
 
 @pytest.mark.datetime_filtering
@@ -1298,7 +1582,7 @@ async def test_select_indexes_no_matches_returns_empty(monkeypatch):
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         ["col-a"],
-        {"gte": "2025-01-01T00:00:00Z", "lte": "2025-01-31T23:59:59Z"},
+        {"gte": "2026-01-01T00:00:00Z", "lte": "2026-01-31T23:59:59Z"},
     )
 
     assert result == ""
@@ -1315,7 +1599,8 @@ async def test_select_indexes_collections_no_datetime_returns_all_for_collection
         {"gte": None, "lte": None},
     )
 
-    assert "items_start_datetime_col-a_2020-02-08" in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" in result
     assert "items_start_datetime_col-a_2020-06-10" in result
     assert "col-b" not in result
 
@@ -1331,7 +1616,8 @@ async def test_select_indexes_no_collections_only_gte(monkeypatch):
     )
 
     assert "items_start_datetime_col-a_2020-06-10" in result
-    assert "items_start_datetime_col-a_2020-02-08" not in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" not in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" in result
     assert "items_start_datetime_col-b_2020-02-15" not in result
 
 
@@ -1342,11 +1628,12 @@ async def test_select_indexes_no_collections_only_lte(monkeypatch):
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         None,
-        {"gte": None, "lte": "2020-02-20T23:59:59Z"},
+        {"gte": None, "lte": "2020-02-14T23:59:59Z"},
     )
 
-    assert "items_start_datetime_col-a_2020-02-08" in result
-    assert "items_start_datetime_col-b_2020-02-15" in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" in result
+    assert "items_start_datetime_col-b_2020-02-15" not in result
     assert "items_start_datetime_col-a_2020-06-10" not in result
 
 
@@ -1357,10 +1644,11 @@ async def test_select_indexes_no_collections_wide_range_returns_all(monkeypatch)
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         None,
-        {"gte": "2019-01-01T00:00:00Z", "lte": "2021-12-31T23:59:59Z"},
+        {"gte": "2020-01-01T00:00:00Z", "lte": "2020-12-31T23:59:59Z"},
     )
 
-    assert "items_start_datetime_col-a_2020-02-08" in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" in result
     assert "items_start_datetime_col-a_2020-06-10" in result
     assert "items_start_datetime_col-b_2020-02-15" in result
 
@@ -1376,7 +1664,8 @@ async def test_select_indexes_no_collections_narrow_range_single_match(monkeypat
     )
 
     assert "items_start_datetime_col-a_2020-06-10" in result
-    assert "items_start_datetime_col-a_2020-02-08" not in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" not in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" in result
     assert "items_start_datetime_col-b_2020-02-15" not in result
 
 
@@ -1387,7 +1676,7 @@ async def test_select_indexes_no_collections_no_matches(monkeypatch):
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         None,
-        {"gte": "2025-01-01T00:00:00Z", "lte": "2025-12-31T23:59:59Z"},
+        {"gte": "2026-01-01T00:00:00Z", "lte": "2026-12-31T23:59:59Z"},
     )
 
     assert result == ""
@@ -1400,11 +1689,12 @@ async def test_select_indexes_multiple_collections_datetime(monkeypatch):
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         ["col-a", "col-b"],
-        {"gte": "2020-02-01T00:00:00Z", "lte": "2020-02-28T23:59:59Z"},
+        {"gte": "2020-02-20T00:00:00Z", "lte": "2020-02-22T23:59:59Z"},
     )
 
-    assert "items_start_datetime_col-a_2020-02-08" in result
     assert "items_start_datetime_col-b_2020-02-15" in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" not in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" in result
     assert "items_start_datetime_col-a_2020-06-10" not in result
 
 
@@ -1415,8 +1705,9 @@ async def test_select_indexes_boundary_date_match(monkeypatch):
     sel = _make_selector(monkeypatch)
     result = await sel.select_indexes(
         None,
-        {"gte": "2020-02-16T00:00:00Z", "lte": "2020-02-16T23:59:59Z"},
+        {"gte": "2020-02-09T00:00:00Z", "lte": "2020-02-09T23:59:59Z"},
     )
 
-    assert "items_start_datetime_col-a_2020-02-08" in result
-    assert "items_start_datetime_col-b_2020-02-15" in result
+    assert "items_start_datetime_col-a_2020-02-08-2020-02-09" in result
+    assert "items_start_datetime_col-a_2020-02-10-2020-06-09" not in result
+    assert "items_start_datetime_col-b_2020-02-15" not in result


### PR DESCRIPTION
**Description:**

Add De Morgan's law test cases for CQL2 datetime filtering and closed index aliases to test index selection. A test cases are `NOT (A AND B) = (NOT A) OR (NOT B) NOT (A OR B) = (NOT A) AND (NOT B)`. The SELECTOR_ALIASES is updated with a closed index alias to support range-based index selection, along with an overlapping index.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog