### PR TITLE
fix: use get_bool_env for ENABLE_DATETIME_INDEX_FILTERING checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Use `get_bool_env` instead of `os.getenv` for `ENABLE_DATETIME_INDEX_FILTERING` checks to ensure proper boolean evaluation of the environment variable. [#731](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/731)
+
 ### Removed
 
 - geojson-pydantic dependency. [#728](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/728)

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1429,7 +1429,7 @@ class BulkTransactionsClient(BaseBulkTransactionsClient):
         """
         request = kwargs.get("request")
 
-        if os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+        if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
             raise HTTPException(
                 status_code=400,
                 detail="The /collections/{collection_id}/bulk_items endpoint is invalid when ENABLE_DATETIME_INDEX_FILTERING is set to true. Try using the /collections/{collection_id}/items endpoint.",

--- a/stac_fastapi/tests/api/test_api.py
+++ b/stac_fastapi/tests/api/test_api.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     from elasticsearch import exceptions
 
+from stac_fastapi.core.utilities import get_bool_env
 from stac_fastapi.sfeos_helpers.database import (
     retry_on_connection_error,
     retry_on_datetime_not_found,
@@ -534,7 +535,7 @@ async def test_search_point_does_not_intersect(app_client, ctx):
 
 @pytest.mark.asyncio
 async def test_datetime_response_format(app_client, txn_client, ctx):
-    if os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     first_item = dict(ctx.item)
@@ -574,7 +575,7 @@ async def test_datetime_response_format(app_client, txn_client, ctx):
 
 @pytest.mark.asyncio
 async def test_datetime_non_interval(app_client, txn_client, ctx):
-    if os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     first_item = dict(ctx.item)
@@ -613,7 +614,7 @@ async def test_datetime_non_interval(app_client, txn_client, ctx):
 
 @pytest.mark.asyncio
 async def test_datetime_interval(app_client, txn_client, ctx):
-    if os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     first_item = dict(ctx.item)
@@ -652,7 +653,7 @@ async def test_datetime_interval(app_client, txn_client, ctx):
 
 @pytest.mark.asyncio
 async def test_datetime_bad_non_interval(app_client, txn_client, ctx):
-    if os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     first_item = dict(ctx.item)
@@ -691,7 +692,7 @@ async def test_datetime_bad_non_interval(app_client, txn_client, ctx):
 
 @pytest.mark.asyncio
 async def test_datetime_bad_interval(app_client, txn_client, ctx):
-    if os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     first_item = dict(ctx.item)

--- a/stac_fastapi/tests/database/test_database.py
+++ b/stac_fastapi/tests/database/test_database.py
@@ -22,6 +22,7 @@ else:
         database_logic as backend_database_logic_module,
     )
 
+from stac_fastapi.core.utilities import get_bool_env
 from stac_fastapi.sfeos_helpers.database import (
     filter_indexes_by_datetime,
     filter_indexes_by_datetime_range,
@@ -829,7 +830,7 @@ async def test_apply_cql2_filter_checks_search_and_metadata(
     collection_ids,
     expected_metadata,
 ):
-    if not os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if not get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     queryables_mapping = {
@@ -921,7 +922,7 @@ async def test_resolve_cql2_indexes_with_collections_datetime(
     expected_index_param,
     expected_collection_ids,
 ):
-    if not os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if not get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     index_selector = _make_selector(monkeypatch)
@@ -951,7 +952,7 @@ async def test_index_mapping_collections(ctx):
 
 @pytest.mark.asyncio
 async def test_index_mapping_items(txn_client, load_test_data):
-    if os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     collection = load_test_data("test_collection.json")

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -13,6 +13,7 @@ from stac_pydantic import api
 
 from stac_fastapi.core.core import CoreClient
 from stac_fastapi.core.datetime_utils import datetime_to_str, now_to_rfc3339_str
+from stac_fastapi.core.utilities import get_bool_env
 from stac_fastapi.types.core import LandingPageMixin
 
 from ..conftest import create_collection, create_item, refresh_indices
@@ -1002,7 +1003,7 @@ async def _search_and_get_ids(
 async def test_search_datetime_with_null_datetime(
     app_client, txn_client, load_test_data
 ):
-    if os.getenv("ENABLE_DATETIME_INDEX_FILTERING"):
+    if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
     """Test datetime filtering when properties.datetime is null or set, ensuring start_datetime and end_datetime are set when datetime is null."""


### PR DESCRIPTION
**Related Issue(s):**

- #726 

**Description:**


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog