### PR TITLE
helm: allow disabling automatic image suffix, add extra volumes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added test for conformance endpoint in catalogs extension. [#727](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/727)
+- Helm chart: added `app.image.addSuffix` bool (default `true`) to allow disabling the automatic `-es`/`-os` suffix on the image repository. [#743](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/743)
+- Helm chart: added `app.extraVolumeMounts` and `app.extraVolumes` to support mounting additional volumes into the application container. [#743](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/743)
 
 ### Changed
 

--- a/helm-chart/stac-fastapi/templates/_helpers.tpl
+++ b/helm-chart/stac-fastapi/templates/_helpers.tpl
@@ -213,11 +213,16 @@ Create the image repository with tag
 {{- define "stac-fastapi.image" -}}
 {{- $registry := .Values.global.imageRegistry | default .Values.app.image.repository }}
 {{- $tag := .Values.app.image.tag | default .Chart.AppVersion }}
-{{- if eq .Values.backend "elasticsearch" }}
-{{- printf "%s-es:%s" $registry $tag }}
-{{- else if eq .Values.backend "opensearch" }}
-{{- printf "%s-os:%s" $registry $tag }}
+{{- $backend := .Values.backend }}
+{{- $suffix := "" }}
+{{- if .Values.app.image.addSuffix }}
+  {{- if eq $backend "elasticsearch" }}
+    {{- $suffix = "-es" }}
+  {{- else if eq $backend "opensearch" }}
+    {{- $suffix = "-os" }}
+  {{- end }}
 {{- end }}
+{{- printf "%s%s:%s" $registry $suffix $tag }}
 {{- end }}
 
 {{/*

--- a/helm-chart/stac-fastapi/templates/deployment.yaml
+++ b/helm-chart/stac-fastapi/templates/deployment.yaml
@@ -78,6 +78,14 @@ spec:
             {{- include "stac-fastapi.environment" . | nindent 12 }}
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
+          {{- with .Values.app.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.app.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.app.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/stac-fastapi/values.yaml
+++ b/helm-chart/stac-fastapi/values.yaml
@@ -23,6 +23,8 @@ app:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion
     tag: ""
+    # Automatically add -os for Opensearch and -es for Elasticsearch to the repository
+    addSuffix: true
 
   # Image pull secrets
   imagePullSecrets: []
@@ -171,6 +173,10 @@ app:
     # SSL configuration
     ES_USE_SSL: "false"
     ES_VERIFY_CERTS: "false"
+
+  # Additional volumes and volume mounts for the application container
+  extraVolumeMounts: []
+  extraVolumes: []
 
   # Additional environment variables from secrets
   envFromSecret: {}


### PR DESCRIPTION

**Description:**

- Add addSuffix bool (default true) to optionally disable the automatic -es/-os suffix appended to the image repository. It may be needed to disable automatic prefix when working with custom images, or tools like the ArgoCD Image Updater or the Renovate Bot. 
- Add extraVolumeMounts and extraVolumes to the main container. This allows to apply custom configurations using files such as STAC_FASTAPI_ES_MAPPINGS_FILE, STAC_QUERYABLES_CONFIG, or other configurations not foreseen by this chart.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog