### PR TITLE
Update to stac-fastapi-catalogs-extension v0.3.0, add update scoped collection, update error handling/ messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added test for conformance endpoint in catalogs extension. [#727](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/727)
+- Added update scoped collection endpoint. [#744](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/744)
 
 ### Changed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Updated
 
 - Updated catalogs extension to v0.2.0. [#727](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/727)
+- Updated catalogs extension to v0.3.0. [#744](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/744)
 
 ## [v6.16.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated catalogs extension to v0.2.0. [#727](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/727)
 - Updated catalogs extension to v0.3.0. [#744](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/744)
+- Updated error handling and messaging related to the Catalogs extension. [#744](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/744)
 
 ## [v6.16.0] - 2026-04-16
 

--- a/stac_fastapi/core/pyproject.toml
+++ b/stac_fastapi/core/pyproject.toml
@@ -54,7 +54,7 @@ sentry = [
     "sentry-sdk>=2.49,<2.61",
 ]
 catalogs = [
-    "stac-fastapi-catalogs-extension==0.2.0",
+    "stac-fastapi-catalogs-extension==0.3.0",
 ]
 
 [project.urls]

--- a/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
+++ b/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
@@ -255,8 +255,10 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                             "title": child.get("title", child_id),
                         }
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(
+                    f"Failed to fetch children for catalog {original_catalog.get('id')}: {e}"
+                )
 
             # Filter all links in the catalog
             catalog_dict["links"] = [self._link_to_dict(link) for link in catalog_links]
@@ -289,7 +291,14 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                 and link.get("rel") not in ("parent", "child", "children")
             ]
 
-        await self.database.create_catalog(db_catalog_dict, refresh=True)
+        try:
+            await self.database.create_catalog(db_catalog_dict, refresh=True)
+        except Exception as e:
+            logger.error(
+                f"Error creating catalog {db_catalog_dict.get('id')}: {e}",
+                exc_info=True,
+            )
+            raise
         created_obj = self.catalog_serializer.db_to_stac(
             db_catalog_dict, request, extensions=["CatalogsExtension"]
         )
@@ -437,7 +446,11 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                 and link.get("rel") not in ("parent", "child", "children")
             ]
 
-        await self.database.create_catalog(db_catalog_dict, refresh=True)
+        try:
+            await self.database.create_catalog(db_catalog_dict, refresh=True)
+        except Exception as e:
+            logger.error(f"Error updating catalog {catalog_id}: {e}", exc_info=True)
+            raise
         updated = await self.database.find_catalog(catalog_id)
         updated_obj = self.catalog_serializer.db_to_stac(
             updated, request, extensions=["CatalogsExtension"]
@@ -456,7 +469,11 @@ class CatalogsClient(AsyncBaseCatalogsClient):
         **kwargs,
     ) -> None:
         """Delete a catalog."""
-        await self.database.delete_catalog(catalog_id, refresh=True)
+        try:
+            await self.database.delete_catalog(catalog_id, refresh=True)
+        except Exception as e:
+            logger.error(f"Error deleting catalog {catalog_id}: {e}", exc_info=True)
+            raise
 
     async def get_catalog_collections(
         self,
@@ -468,14 +485,9 @@ class CatalogsClient(AsyncBaseCatalogsClient):
     ) -> Collections | Response:
         """Get collections linked from a specific catalog."""
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
-        except Exception as e:
-            raise NotFoundError(f"Catalog {catalog_id} not found") from e
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
+            raise NotFoundError(f"Catalog {catalog_id} not found")
 
         if limit is None:
             # 1. Try to get from kwargs
@@ -564,14 +576,9 @@ class CatalogsClient(AsyncBaseCatalogsClient):
     ) -> Catalogs | Response:
         """Get all sub-catalogs of a specific catalog with pagination."""
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
-        except Exception as e:
-            raise NotFoundError(f"Catalog {catalog_id} not found") from e
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
+            raise NotFoundError(f"Catalog {catalog_id} not found")
 
         limit = limit or 10
         (
@@ -632,8 +639,10 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                             "title": child.get("title", child_id),
                         }
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(
+                    f"Failed to fetch children for catalog {cat.get('id')}: {e}"
+                )
 
             catalog_dict["links"] = [self._link_to_dict(link) for link in catalog_links]
             catalogs.append(catalog_dict)
@@ -695,7 +704,14 @@ class CatalogsClient(AsyncBaseCatalogsClient):
             existing = await self.database.find_catalog(cat_id)
             # Link existing catalog
             self._add_parent_id(existing, catalog_id)
-            await self.database.create_catalog(existing, refresh=True)
+            try:
+                await self.database.create_catalog(existing, refresh=True)
+            except Exception as e:
+                logger.error(
+                    f"Error linking existing catalog {cat_id} to catalog {catalog_id}: {e}",
+                    exc_info=True,
+                )
+                raise
             existing_obj = self.catalog_serializer.db_to_stac(
                 existing, request, extensions=["CatalogsExtension"]
             )
@@ -719,7 +735,14 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                     and link.get("rel") not in ("parent", "child", "children")
                 ]
 
-            await self.database.create_catalog(db_catalog_dict, refresh=True)
+            try:
+                await self.database.create_catalog(db_catalog_dict, refresh=True)
+            except Exception as e:
+                logger.error(
+                    f"Error creating sub-catalog {db_catalog_dict.get('id')} under catalog {catalog_id}: {e}",
+                    exc_info=True,
+                )
+                raise
             new_obj = self.catalog_serializer.db_to_stac(
                 db_catalog_dict, request, extensions=["CatalogsExtension"]
             )
@@ -738,14 +761,9 @@ class CatalogsClient(AsyncBaseCatalogsClient):
     ) -> Collection | Response:
         """Create a new collection or link an existing collection to catalog."""
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
-        except Exception as e:
-            raise NotFoundError(f"Catalog {catalog_id} not found") from e
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
+            raise NotFoundError(f"Catalog {catalog_id} not found")
 
         # Get collection ID safely
         if isinstance(collection, dict):
@@ -764,24 +782,46 @@ class CatalogsClient(AsyncBaseCatalogsClient):
             try:
                 existing = await self.database.find_collection(col_id)
                 self._add_parent_id(existing, catalog_id)
-                await self.database.update_collection(col_id, existing, refresh=True)
-                collection_obj = self.collection_serializer.db_to_stac_in_catalog(
-                    existing,
-                    request,
-                    catalog_id=catalog_id,
-                    extensions=["CatalogsExtension"],
-                )
-                # Return 201 Created for all collection operations
-                content = self._to_dict(collection_obj)
-                return JSONResponse(content=content, status_code=201)
             except NotFoundError:
                 raise NotFoundError(f"Collection {col_id} not found")
+
+            try:
+                await self.database.update_collection(col_id, existing, refresh=True)
+            except Exception as e:
+                logger.error(
+                    f"Error linking existing collection {col_id} to catalog {catalog_id} (ObjectUri): {e}",
+                    exc_info=True,
+                )
+                raise
+
+            collection_obj = self.collection_serializer.db_to_stac_in_catalog(
+                existing,
+                request,
+                catalog_id=catalog_id,
+                extensions=["CatalogsExtension"],
+            )
+            # Return 201 Created for all collection operations
+            content = self._to_dict(collection_obj)
+            return JSONResponse(content=content, status_code=201)
 
         # Full collection data provided - try to link existing or create new
         try:
             existing = await self.database.find_collection(col_id)
             self._add_parent_id(existing, catalog_id)
-            await self.database.update_collection(col_id, existing, refresh=True)
+        except NotFoundError:
+            # Collection doesn't exist, will create new one below
+            pass
+        else:
+            # Collection exists, link it
+            try:
+                await self.database.update_collection(col_id, existing, refresh=True)
+            except Exception as e:
+                logger.error(
+                    f"Error linking existing collection {col_id} to catalog {catalog_id}: {e}",
+                    exc_info=True,
+                )
+                raise
+
             collection_obj = self.collection_serializer.db_to_stac_in_catalog(
                 existing,
                 request,
@@ -791,30 +831,37 @@ class CatalogsClient(AsyncBaseCatalogsClient):
             # Return 201 Created for full collection data (even if linking existing)
             content = self._to_dict(collection_obj)
             return JSONResponse(content=content, status_code=201)
-        except NotFoundError:
-            # Create new collection
-            col_dict = self._to_dict(collection)
-            col_dict["parent_ids"] = [catalog_id]
 
-            # Filter out dynamic links
-            if "links" in col_dict:
-                col_dict["links"] = [
-                    link
-                    for link in col_dict["links"]
-                    if isinstance(link, dict)
-                    and link.get("rel") not in ("parent", "child", "children")
-                ]
+        # Create new collection
+        col_dict = self._to_dict(collection)
+        col_dict["parent_ids"] = [catalog_id]
 
+        # Filter out dynamic links
+        if "links" in col_dict:
+            col_dict["links"] = [
+                link
+                for link in col_dict["links"]
+                if isinstance(link, dict)
+                and link.get("rel") not in ("parent", "child", "children")
+            ]
+
+        try:
             await self.database.create_collection(col_dict, refresh=True)
-            collection_obj = self.collection_serializer.db_to_stac_in_catalog(
-                col_dict,
-                request,
-                catalog_id=catalog_id,
-                extensions=["CatalogsExtension"],
+        except Exception as e:
+            logger.error(
+                f"Error creating collection {col_dict.get('id')} in catalog {catalog_id}: {e}",
+                exc_info=True,
             )
-            # Return 201 Created for new collection
-            content = self._to_dict(collection_obj)
-            return JSONResponse(content=content, status_code=201)
+            raise
+        collection_obj = self.collection_serializer.db_to_stac_in_catalog(
+            col_dict,
+            request,
+            catalog_id=catalog_id,
+            extensions=["CatalogsExtension"],
+        )
+        # Return 201 Created for new collection
+        content = self._to_dict(collection_obj)
+        return JSONResponse(content=content, status_code=201)
 
     async def get_catalog_collection(
         self,
@@ -825,24 +872,16 @@ class CatalogsClient(AsyncBaseCatalogsClient):
     ) -> Collection | Response:
         """Get a specific collection from a catalog (Scoped Route)."""
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
-        except Exception:
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
             raise NotFoundError(f"Catalog {catalog_id} not found")
 
         # Get collection and validate it belongs to this catalog
-        try:
-            collection_dict = await self.database.get_catalog_collection(
-                catalog_id=catalog_id,
-                collection_id=collection_id,
-                request=request,
-            )
-        except Exception:
-            raise NotFoundError(f"Collection {collection_id} not found")
+        collection_dict = await self.database.get_catalog_collection(
+            catalog_id=catalog_id,
+            collection_id=collection_id,
+            request=request,
+        )
 
         # Verify collection is in this catalog's parent_ids
         parent_ids = collection_dict.get("parent_ids", [])
@@ -892,24 +931,16 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                 collection is not linked to the catalog.
         """
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
-        except Exception:
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
             raise NotFoundError(f"Catalog {catalog_id} not found")
 
         # Get collection and validate it belongs to this catalog
-        try:
-            collection_dict = await self.database.get_catalog_collection(
-                catalog_id=catalog_id,
-                collection_id=collection_id,
-                request=request,
-            )
-        except Exception:
-            raise NotFoundError(f"Collection {collection_id} not found")
+        collection_dict = await self.database.get_catalog_collection(
+            catalog_id=catalog_id,
+            collection_id=collection_id,
+            request=request,
+        )
 
         # Verify collection is in this catalog's parent_ids
         parent_ids = collection_dict.get("parent_ids", [])
@@ -932,7 +963,16 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                 and link.get("rel") not in ("parent", "child", "children")
             ]
 
-        await self.database.update_collection(collection_id, updated_dict, refresh=True)
+        try:
+            await self.database.update_collection(
+                collection_id, updated_dict, refresh=True
+            )
+        except Exception as e:
+            logger.error(
+                f"Error updating collection {collection_id} in catalog {catalog_id}: {e}",
+                exc_info=True,
+            )
+            raise
 
         # Fetch updated collection
         updated_collection = await self.database.get_catalog_collection(
@@ -962,22 +1002,16 @@ class CatalogsClient(AsyncBaseCatalogsClient):
     ) -> None:
         """Unlink a collection from a catalog."""
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
+            raise NotFoundError(f"Catalog {catalog_id} not found")
 
         # Get collection and validate it belongs to this catalog
-        try:
-            collection_dict = await self.database.get_catalog_collection(
-                catalog_id=catalog_id,
-                collection_id=collection_id,
-                request=request,
-            )
-        except NotFoundError:
-            raise
+        collection_dict = await self.database.get_catalog_collection(
+            catalog_id=catalog_id,
+            collection_id=collection_id,
+            request=request,
+        )
 
         # Verify collection is in this catalog's parent_ids
         parent_ids = collection_dict.get("parent_ids", [])
@@ -988,9 +1022,16 @@ class CatalogsClient(AsyncBaseCatalogsClient):
 
         # Remove this catalog from parent_ids
         self._remove_parent_id(collection_dict, catalog_id)
-        await self.database.update_collection(
-            collection_id, collection_dict, refresh=True
-        )
+        try:
+            await self.database.update_collection(
+                collection_id, collection_dict, refresh=True
+            )
+        except Exception as e:
+            logger.error(
+                f"Error unlinking collection {collection_id} from catalog {catalog_id}: {e}",
+                exc_info=True,
+            )
+            raise
 
     async def get_catalog_collection_items(
         self,
@@ -1009,26 +1050,16 @@ class CatalogsClient(AsyncBaseCatalogsClient):
         if limit <= 0:
             limit = 10
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
-        except Exception as e:
-            raise NotFoundError(f"Catalog {catalog_id} not found") from e
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
+            raise NotFoundError(f"Catalog {catalog_id} not found")
 
         # Validate collection exists and belongs to this catalog
-        try:
-            collection_dict = await self.database.get_catalog_collection(
-                catalog_id=catalog_id,
-                collection_id=collection_id,
-                request=request,
-            )
-        except NotFoundError:
-            raise
-        except Exception as e:
-            raise NotFoundError(f"Collection {collection_id} not found") from e
+        collection_dict = await self.database.get_catalog_collection(
+            catalog_id=catalog_id,
+            collection_id=collection_id,
+            request=request,
+        )
 
         # Verify collection is in this catalog's parent_ids
         parent_ids = collection_dict.get("parent_ids", [])
@@ -1175,26 +1206,16 @@ class CatalogsClient(AsyncBaseCatalogsClient):
     ) -> Item | Response:
         """Get a specific item from a collection in a catalog."""
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
-        except Exception as e:
-            raise NotFoundError(f"Catalog {catalog_id} not found") from e
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
+            raise NotFoundError(f"Catalog {catalog_id} not found")
 
         # Validate collection exists and belongs to this catalog
-        try:
-            collection_dict = await self.database.get_catalog_collection(
-                catalog_id=catalog_id,
-                collection_id=collection_id,
-                request=request,
-            )
-        except NotFoundError:
-            raise
-        except Exception as e:
-            raise NotFoundError(f"Collection {collection_id} not found") from e
+        collection_dict = await self.database.get_catalog_collection(
+            catalog_id=catalog_id,
+            collection_id=collection_id,
+            request=request,
+        )
 
         # Verify collection is in this catalog's parent_ids
         parent_ids = collection_dict.get("parent_ids", [])
@@ -1286,14 +1307,9 @@ class CatalogsClient(AsyncBaseCatalogsClient):
     ) -> Children | Response:
         """Get all children (Catalogs and Collections) of a specific catalog."""
         # Validate catalog exists
-        try:
-            catalog = await self.database.find_catalog(catalog_id)
-            if not catalog:
-                raise NotFoundError(f"Catalog {catalog_id} not found")
-        except NotFoundError:
-            raise
-        except Exception as e:
-            raise NotFoundError(f"Catalog {catalog_id} not found") from e
+        catalog = await self.database.find_catalog(catalog_id)
+        if not catalog:
+            raise NotFoundError(f"Catalog {catalog_id} not found")
 
         limit = limit or 10
         (
@@ -1380,6 +1396,7 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                 "https://api.stacspec.org/v1.0.0/core",
                 "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs",
                 "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction",
+                "https://api.stacspec.org/v1.0.0-rc.2/children",
             ]
         }
 
@@ -1398,10 +1415,14 @@ class CatalogsClient(AsyncBaseCatalogsClient):
         **kwargs,
     ) -> None:
         """Unlink a sub-catalog from its parent."""
-        try:
-            sub_catalog = await self.database.find_catalog(sub_catalog_id)
-        except NotFoundError:
-            raise NotFoundError(f"Catalog {sub_catalog_id} not found")
+        sub_catalog = await self.database.find_catalog(sub_catalog_id)
 
         self._remove_parent_id(sub_catalog, catalog_id)
-        await self.database.create_catalog(sub_catalog, refresh=True)
+        try:
+            await self.database.create_catalog(sub_catalog, refresh=True)
+        except Exception as e:
+            logger.error(
+                f"Error unlinking sub-catalog {sub_catalog_id} from catalog {catalog_id}: {e}",
+                exc_info=True,
+            )
+            raise

--- a/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
+++ b/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
@@ -863,6 +863,96 @@ class CatalogsClient(AsyncBaseCatalogsClient):
         ]
         return JSONResponse(content=collection_dict_out)
 
+    async def update_catalog_collection(
+        self,
+        catalog_id: str,
+        collection_id: str,
+        collection: Collection,
+        request: Request | None = None,
+        **kwargs,
+    ) -> Collection | Response:
+        """Update a collection's metadata within a catalog context (Scoped Route).
+
+        This method updates collection metadata while ensuring the collection
+        remains linked to the specified catalog. This provides DAG safety by
+        operating within a specific catalog context.
+
+        Args:
+            catalog_id: The ID of the catalog.
+            collection_id: The ID of the collection to update.
+            collection: The updated collection data.
+            request: FastAPI request object.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            The updated collection.
+
+        Raises:
+            NotFoundError: If the catalog or collection is not found, or if the
+                collection is not linked to the catalog.
+        """
+        # Validate catalog exists
+        try:
+            catalog = await self.database.find_catalog(catalog_id)
+            if not catalog:
+                raise NotFoundError(f"Catalog {catalog_id} not found")
+        except NotFoundError:
+            raise
+        except Exception:
+            raise NotFoundError(f"Catalog {catalog_id} not found")
+
+        # Get collection and validate it belongs to this catalog
+        try:
+            collection_dict = await self.database.get_catalog_collection(
+                catalog_id=catalog_id,
+                collection_id=collection_id,
+                request=request,
+            )
+        except Exception:
+            raise NotFoundError(f"Collection {collection_id} not found")
+
+        # Verify collection is in this catalog's parent_ids
+        parent_ids = collection_dict.get("parent_ids", [])
+        if catalog_id not in parent_ids:
+            raise NotFoundError(
+                f"Collection {collection_id} not linked to catalog {catalog_id}"
+            )
+
+        # Update collection with new data, preserving parent_ids
+        updated_dict = self._to_dict(collection)
+        updated_dict["id"] = collection_id
+        updated_dict["parent_ids"] = parent_ids  # Preserve catalog linkage
+
+        # Filter out dynamic links
+        if "links" in updated_dict:
+            updated_dict["links"] = [
+                link
+                for link in updated_dict["links"]
+                if isinstance(link, dict)
+                and link.get("rel") not in ("parent", "child", "children")
+            ]
+
+        await self.database.update_collection(collection_id, updated_dict, refresh=True)
+
+        # Fetch updated collection
+        updated_collection = await self.database.get_catalog_collection(
+            catalog_id=catalog_id,
+            collection_id=collection_id,
+            request=request,
+        )
+
+        collection_obj = self.collection_serializer.db_to_stac_in_catalog(
+            updated_collection,
+            request,
+            catalog_id=catalog_id,
+            extensions=["CatalogsExtension"],
+        )
+        collection_dict_out = self._to_dict(collection_obj)
+        collection_dict_out["links"] = [
+            self._link_to_dict(link) for link in collection_dict_out.get("links", [])
+        ]
+        return JSONResponse(content=collection_dict_out)
+
     async def unlink_catalog_collection(
         self,
         catalog_id: str,
@@ -1288,7 +1378,8 @@ class CatalogsClient(AsyncBaseCatalogsClient):
         return {
             "conformsTo": [
                 "https://api.stacspec.org/v1.0.0/core",
-                "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs",
+                "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs",
+                "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction",
             ]
         }
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1570,12 +1570,18 @@ class DatabaseLogic(BaseDatabaseLogic):
             add_bbox_shape_to_collection(collection)
 
         # Index the collection in the database
-        await self.client.index(
-            index=COLLECTIONS_INDEX,
-            id=collection_id,
-            document=collection,
-            refresh=refresh,
-        )
+        try:
+            await self.client.index(
+                index=COLLECTIONS_INDEX,
+                id=collection_id,
+                document=collection,
+                refresh=refresh,
+            )
+        except Exception as e:
+            logger.error(
+                f"Error indexing collection {collection_id}: {e}", exc_info=True
+            )
+            raise
 
         if self.async_index_inserter.should_create_collection_index():
             await self.async_index_inserter.create_simple_index(
@@ -2091,12 +2097,18 @@ class DatabaseLogic(BaseDatabaseLogic):
             catalog (dict): The catalog document to create.
             refresh (bool): Whether to refresh the index after creation.
         """
-        await self.client.index(
-            index=COLLECTIONS_INDEX,
-            id=catalog.get("id"),
-            body=catalog,
-            refresh=refresh,
-        )
+        try:
+            await self.client.index(
+                index=COLLECTIONS_INDEX,
+                id=catalog.get("id"),
+                body=catalog,
+                refresh=refresh,
+            )
+        except Exception as e:
+            logger.error(
+                f"Error creating catalog {catalog.get('id')}: {e}", exc_info=True
+            )
+            raise
 
     @retry_on_connection_error
     async def find_catalog(self, catalog_id: str) -> dict:
@@ -2131,11 +2143,15 @@ class DatabaseLogic(BaseDatabaseLogic):
             catalog_id (str): The ID of the catalog to delete.
             refresh (bool): Whether to refresh the index after deletion.
         """
-        await self.client.delete(
-            index=COLLECTIONS_INDEX,
-            id=catalog_id,
-            refresh=refresh,
-        )
+        try:
+            await self.client.delete(
+                index=COLLECTIONS_INDEX,
+                id=catalog_id,
+                refresh=refresh,
+            )
+        except Exception as e:
+            logger.error(f"Error deleting catalog {catalog_id}: {e}", exc_info=True)
+            raise
 
     @retry_on_connection_error
     async def get_catalog_children(
@@ -2283,7 +2299,16 @@ class DatabaseLogic(BaseDatabaseLogic):
         if catalog_id not in catalog["parent_ids"]:
             catalog["parent_ids"].append(catalog_id)
 
-        await self.create_catalog(catalog, refresh=self.async_settings.database_refresh)
+        try:
+            await self.create_catalog(
+                catalog, refresh=self.async_settings.database_refresh
+            )
+        except Exception as e:
+            logger.error(
+                f"Error creating sub-catalog {catalog.get('id')} under catalog {catalog_id}: {e}",
+                exc_info=True,
+            )
+            raise
         return catalog
 
     @retry_on_connection_error
@@ -2316,9 +2341,16 @@ class DatabaseLogic(BaseDatabaseLogic):
         if catalog_id not in collection["parent_ids"]:
             collection["parent_ids"].append(catalog_id)
 
-        await self.create_collection(
-            collection, refresh=self.async_settings.database_refresh
-        )
+        try:
+            await self.create_collection(
+                collection, refresh=self.async_settings.database_refresh
+            )
+        except Exception as e:
+            logger.error(
+                f"Error creating collection {collection.get('id')} in catalog {catalog_id}: {e}",
+                exc_info=True,
+            )
+            raise
         return collection
 
     @retry_on_connection_error
@@ -2330,31 +2362,10 @@ class DatabaseLogic(BaseDatabaseLogic):
     ) -> Any:
         """Get a specific collection within a catalog.
 
-        Args:
-            catalog_id (str): The ID of the parent catalog.
-            collection_id (str): The ID of the collection.
-            request (Any): The request object.
-
-        Returns:
-            The collection object.
-
-        Raises:
-            NotFoundError: If the collection or catalog does not exist or are not related.
+        Validation is now handled securely by CatalogsClient.
+        Just return the collection.
         """
-        # Ensure parent catalog exists
-        await self.find_catalog(catalog_id)
-
-        # Get collection
-        collection = await self.find_collection(collection_id)
-
-        # Verify relationship: catalog_id must be in parent_ids
-        parent_ids = collection.get("parent_ids", [])
-        if catalog_id not in parent_ids:
-            raise NotFoundError(
-                f"Collection {collection_id} is not linked to catalog {catalog_id}"
-            )
-
-        return collection
+        return await self.find_collection(collection_id)
 
     @retry_on_connection_error
     async def get_catalog_collection_items(
@@ -2374,12 +2385,9 @@ class DatabaseLogic(BaseDatabaseLogic):
     ) -> Any:
         """Get items for a collection within a catalog.
 
-        Currently, this just proxies to the standard get_items functionality.
-        The relationship check is performed by `get_catalog_collection`.
+        Hierarchy validation is already performed by CatalogsClient.
+        Skip the redundant DB checks and go straight to the search.
         """
-        # Verify strict hierarchy access if needed
-        await self.get_catalog_collection(catalog_id, collection_id, request)
-
         # Build a Search object scoped to this collection
         search = self.make_search()
         search = self.apply_collections_filter(search, [collection_id])
@@ -2391,10 +2399,8 @@ class DatabaseLogic(BaseDatabaseLogic):
         if datetime:
             search, datetime_search = self.apply_datetime_filter(search, datetime)
 
-        # Sorting for scoped items currently mirrors the global items behavior; the
-        # API layer typically parses sortby, so we leave sort_param as None here.
         sort_param = None
-        # ...existing code...
+
         return await self.execute_search(
             search=search,
             limit=limit or 10,
@@ -2412,10 +2418,10 @@ class DatabaseLogic(BaseDatabaseLogic):
         item_id: str,
         request: Any,
     ) -> Any:
-        """Get a specific item from a collection within a catalog."""
-        # Check hierarchy
-        await self.get_catalog_collection(catalog_id, collection_id, request)
+        """Get a specific item from a collection within a catalog.
 
+        Hierarchy validation is already performed by CatalogsClient.
+        """
         return await self.get_one_item(collection_id, item_id)
 
     @retry_on_connection_error
@@ -2426,12 +2432,16 @@ class DatabaseLogic(BaseDatabaseLogic):
         request: Any,
     ) -> Any:
         """Update a catalog."""
-        return await update_catalog_in_index_shared(
-            es_client=self.client,
-            catalog_id=catalog_id,
-            catalog=catalog,
-            refresh=self.async_settings.database_refresh,
-        )
+        try:
+            return await update_catalog_in_index_shared(
+                es_client=self.client,
+                catalog_id=catalog_id,
+                catalog=catalog,
+                refresh=self.async_settings.database_refresh,
+            )
+        except Exception as e:
+            logger.error(f"Error updating catalog {catalog_id}: {e}", exc_info=True)
+            raise
 
     @retry_on_connection_error
     async def get_catalog(

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -1557,12 +1557,18 @@ class DatabaseLogic(BaseDatabaseLogic):
             # Convert bbox to bbox_shape for geospatial queries (ES/OS specific)
             add_bbox_shape_to_collection(collection)
 
-        await self.client.index(
-            index=COLLECTIONS_INDEX,
-            id=collection_id,
-            body=collection,
-            refresh=refresh,
-        )
+        try:
+            await self.client.index(
+                index=COLLECTIONS_INDEX,
+                id=collection_id,
+                body=collection,
+                refresh=refresh,
+            )
+        except Exception as e:
+            logger.error(
+                f"Error indexing collection {collection_id}: {e}", exc_info=True
+            )
+            raise
         if self.async_index_inserter.should_create_collection_index():
             await self.async_index_inserter.create_simple_index(
                 self.client, collection_id
@@ -2060,12 +2066,18 @@ class DatabaseLogic(BaseDatabaseLogic):
             catalog (dict): The catalog document to create.
             refresh (bool): Whether to refresh the index after creation.
         """
-        await self.client.index(
-            index=COLLECTIONS_INDEX,
-            id=catalog.get("id"),
-            body=catalog,
-            refresh=refresh,
-        )
+        try:
+            await self.client.index(
+                index=COLLECTIONS_INDEX,
+                id=catalog.get("id"),
+                body=catalog,
+                refresh=refresh,
+            )
+        except Exception as e:
+            logger.error(
+                f"Error creating catalog {catalog.get('id')}: {e}", exc_info=True
+            )
+            raise
 
     @retry_on_connection_error
     async def find_catalog(self, catalog_id: str) -> dict:
@@ -2100,11 +2112,15 @@ class DatabaseLogic(BaseDatabaseLogic):
             catalog_id (str): The ID of the catalog to delete.
             refresh (bool): Whether to refresh the index after deletion.
         """
-        await self.client.delete(
-            index=COLLECTIONS_INDEX,
-            id=catalog_id,
-            refresh=refresh,
-        )
+        try:
+            await self.client.delete(
+                index=COLLECTIONS_INDEX,
+                id=catalog_id,
+                refresh=refresh,
+            )
+        except Exception as e:
+            logger.error(f"Error deleting catalog {catalog_id}: {e}", exc_info=True)
+            raise
 
     @retry_on_connection_error
     async def get_catalog_children(
@@ -2209,7 +2225,16 @@ class DatabaseLogic(BaseDatabaseLogic):
         if catalog_id not in catalog["parent_ids"]:
             catalog["parent_ids"].append(catalog_id)
 
-        await self.create_catalog(catalog, refresh=self.async_settings.database_refresh)
+        try:
+            await self.create_catalog(
+                catalog, refresh=self.async_settings.database_refresh
+            )
+        except Exception as e:
+            logger.error(
+                f"Error creating sub-catalog {catalog.get('id')} under catalog {catalog_id}: {e}",
+                exc_info=True,
+            )
+            raise
         return catalog
 
     @retry_on_connection_error
@@ -2229,9 +2254,16 @@ class DatabaseLogic(BaseDatabaseLogic):
         if catalog_id not in collection["parent_ids"]:
             collection["parent_ids"].append(catalog_id)
 
-        await self.create_collection(
-            collection, refresh=self.async_settings.database_refresh
-        )
+        try:
+            await self.create_collection(
+                collection, refresh=self.async_settings.database_refresh
+            )
+        except Exception as e:
+            logger.error(
+                f"Error creating collection {collection.get('id')} in catalog {catalog_id}: {e}",
+                exc_info=True,
+            )
+            raise
         return collection
 
     @retry_on_connection_error
@@ -2243,31 +2275,10 @@ class DatabaseLogic(BaseDatabaseLogic):
     ) -> Any:
         """Get a specific collection within a catalog.
 
-        Args:
-            catalog_id (str): The ID of the parent catalog.
-            collection_id (str): The ID of the collection.
-            request (Any): The request object.
-
-        Returns:
-            The collection object.
-
-        Raises:
-            NotFoundError: If the collection or catalog does not exist or are not related.
+        Validation is now handled securely by CatalogsClient.
+        Just return the collection.
         """
-        # Ensure parent catalog exists
-        await self.find_catalog(catalog_id)
-
-        # Get collection
-        collection = await self.find_collection(collection_id)
-
-        # Verify relationship: catalog_id must be in parent_ids
-        parent_ids = collection.get("parent_ids", [])
-        if catalog_id not in parent_ids:
-            raise NotFoundError(
-                f"Collection {collection_id} is not linked to catalog {catalog_id}"
-            )
-
-        return collection
+        return await self.find_collection(collection_id)
 
     @retry_on_connection_error
     async def get_catalog_collection_items(
@@ -2285,11 +2296,12 @@ class DatabaseLogic(BaseDatabaseLogic):
         query: str | None = None,
         fields: list[str] | None = None,
     ) -> Any:
-        """Get items for a collection within a catalog."""
-        # Check hierarchy
-        await self.get_catalog_collection(catalog_id, collection_id, request)
+        """Get items for a collection within a catalog.
 
-        # We need to construct a Search object for items.
+        Hierarchy validation is already performed by CatalogsClient.
+        Skip the redundant DB checks and go straight to the search.
+        """
+        # Build a Search object scoped to this collection
         search = self.make_search()
         search = self.apply_collections_filter(search, [collection_id])
 
@@ -2301,8 +2313,6 @@ class DatabaseLogic(BaseDatabaseLogic):
             search, datetime_search = self.apply_datetime_filter(search, datetime)
 
         sort_param = None
-        if sortby:
-            pass
 
         return await self.execute_search(
             search=search,
@@ -2321,10 +2331,10 @@ class DatabaseLogic(BaseDatabaseLogic):
         item_id: str,
         request: Any,
     ) -> Any:
-        """Get a specific item from a collection within a catalog."""
-        # Check hierarchy
-        await self.get_catalog_collection(catalog_id, collection_id, request)
+        """Get a specific item from a collection within a catalog.
 
+        Hierarchy validation is already performed by CatalogsClient.
+        """
         return await self.get_one_item(collection_id, item_id)
 
     @retry_on_connection_error
@@ -2335,12 +2345,16 @@ class DatabaseLogic(BaseDatabaseLogic):
         request: Any,
     ) -> Any:
         """Update a catalog."""
-        return await update_catalog_in_index_shared(
-            es_client=self.client,
-            catalog_id=catalog_id,
-            catalog=catalog,
-            refresh=self.async_settings.database_refresh,
-        )
+        try:
+            return await update_catalog_in_index_shared(
+                es_client=self.client,
+                catalog_id=catalog_id,
+                catalog=catalog,
+                refresh=self.async_settings.database_refresh,
+            )
+        except Exception as e:
+            logger.error(f"Error updating catalog {catalog_id}: {e}", exc_info=True)
+            raise
 
     @retry_on_connection_error
     async def get_catalog(

--- a/stac_fastapi/tests/extensions/test_catalogs.py
+++ b/stac_fastapi/tests/extensions/test_catalogs.py
@@ -901,6 +901,75 @@ async def test_create_catalog_collection_adds_parent_id(
 
 
 @pytest.mark.asyncio
+async def test_update_catalog_collection_preserves_parent_ids(
+    catalogs_app_client, load_test_data
+):
+    """Test that updating a collection via scoped PUT preserves all parent_ids."""
+    # Create two catalogs
+    catalog_ids = []
+    for i in range(2):
+        test_catalog = load_test_data("test_catalog.json")
+        catalog_id = f"test-catalog-{uuid.uuid4()}-{i}"
+        test_catalog["id"] = catalog_id
+
+        catalog_resp = await catalogs_app_client.post("/catalogs", json=test_catalog)
+        assert catalog_resp.status_code == 201
+        catalog_ids.append(catalog_id)
+
+    # Create a collection in the first catalog
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    create_resp = await catalogs_app_client.post(
+        f"/catalogs/{catalog_ids[0]}/collections", json=test_collection
+    )
+    assert create_resp.status_code == 201
+
+    # Add the same collection to the second catalog (multi-parent)
+    add_resp = await catalogs_app_client.post(
+        f"/catalogs/{catalog_ids[1]}/collections", json={"id": collection_id}
+    )
+    assert add_resp.status_code == 201
+
+    # Verify collection has both parent_ids by getting it via first catalog endpoint
+    get_resp = await catalogs_app_client.get(
+        f"/catalogs/{catalog_ids[0]}/collections/{collection_id}"
+    )
+    assert get_resp.status_code == 200
+
+    # Update the collection via the first catalog's scoped endpoint
+    updated_collection = load_test_data("test_collection.json")
+    updated_collection["id"] = collection_id
+    updated_collection["title"] = "Updated Title"
+    updated_collection["description"] = "Updated Description"
+
+    update_resp = await catalogs_app_client.put(
+        f"/catalogs/{catalog_ids[0]}/collections/{collection_id}",
+        json=updated_collection,
+    )
+    assert update_resp.status_code == 200
+
+    updated_data = update_resp.json()
+    assert updated_data["title"] == "Updated Title"
+    assert updated_data["description"] == "Updated Description"
+
+    # Verify the collection is still accessible from both catalogs
+    # (parent_ids should have been preserved)
+    for catalog_id in catalog_ids:
+        get_resp = await catalogs_app_client.get(
+            f"/catalogs/{catalog_id}/collections/{collection_id}"
+        )
+        assert (
+            get_resp.status_code == 200
+        ), f"Collection should still be accessible from catalog {catalog_id}"
+
+        data = get_resp.json()
+        assert data["title"] == "Updated Title"
+        assert data["description"] == "Updated Description"
+
+
+@pytest.mark.asyncio
 async def test_add_existing_collection_to_catalog(
     catalogs_app_client, load_test_data, ctx
 ):
@@ -3829,9 +3898,9 @@ async def test_catalog_conformance_endpoint(catalogs_app_client, load_test_data)
 
     # Check for required conformance classes
     assert "https://api.stacspec.org/v1.0.0/core" in conforms_to
-    assert "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs" in conforms_to
-    assert "https://api.stacspec.org/v1.0.0-rc.2/children" in conforms_to
+    assert "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs" in conforms_to
     assert (
-        "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs/transaction"
+        "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction"
         in conforms_to
     )
+    assert "https://api.stacspec.org/v1.0.0-rc.2/children" in conforms_to

--- a/stac_fastapi/tests/extensions/test_catalogs.py
+++ b/stac_fastapi/tests/extensions/test_catalogs.py
@@ -3904,3 +3904,114 @@ async def test_catalog_conformance_endpoint(catalogs_app_client, load_test_data)
         in conforms_to
     )
     assert "https://api.stacspec.org/v1.0.0-rc.2/children" in conforms_to
+
+
+# ============================================================================
+# Database Error Handling & Observability Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_catalog_create_logs_error_with_traceback(txn_client, caplog):
+    """Test that catalog creation failures log errors with full stack traces."""
+    import logging
+    from unittest.mock import patch
+
+    caplog.set_level(logging.ERROR)
+
+    # Mock the Elasticsearch client to raise an error
+    async def mock_index_error(*args, **kwargs):
+        raise Exception("Simulated index corruption error")
+
+    with patch.object(
+        txn_client.database.client, "index", side_effect=mock_index_error
+    ):
+        catalog = {
+            "id": "test-catalog",
+            "type": "Catalog",
+            "title": "Test Catalog",
+            "description": "Test Description",
+            "parent_ids": [],
+        }
+
+        try:
+            await txn_client.database.create_catalog(catalog, refresh=True)
+        except Exception:
+            pass  # Expected to fail
+
+    # Verify error was logged with stack trace
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) > 0, "Expected ERROR level log"
+    assert any(
+        "Error creating catalog" in r.message for r in error_records
+    ), "Expected 'Error creating catalog' in error log"
+    assert any(
+        r.exc_info is not None for r in error_records
+    ), "Expected stack trace (exc_info) in error log"
+
+
+@pytest.mark.asyncio
+async def test_catalog_delete_logs_error_with_traceback(txn_client, caplog):
+    """Test that catalog deletion failures log errors with full stack traces."""
+    import logging
+    from unittest.mock import patch
+
+    caplog.set_level(logging.ERROR)
+
+    # Mock the Elasticsearch client to raise an error
+    async def mock_delete_error(*args, **kwargs):
+        raise Exception("Simulated deletion error")
+
+    with patch.object(
+        txn_client.database.client, "delete", side_effect=mock_delete_error
+    ):
+        try:
+            await txn_client.database.delete_catalog("test-catalog", refresh=True)
+        except Exception:
+            pass  # Expected to fail
+
+    # Verify error was logged with stack trace
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) > 0
+    assert any("Error deleting catalog" in r.message for r in error_records)
+    assert any(r.exc_info is not None for r in error_records)
+
+
+@pytest.mark.asyncio
+async def test_collection_index_logs_error_with_traceback(txn_client, caplog):
+    """Test that collection indexing failures log errors with full stack traces."""
+    import logging
+    from unittest.mock import patch
+
+    caplog.set_level(logging.ERROR)
+
+    # Mock the Elasticsearch client to raise an error
+    async def mock_index_error(*args, **kwargs):
+        raise Exception("Simulated collection index error")
+
+    with patch.object(
+        txn_client.database.client, "index", side_effect=mock_index_error
+    ):
+        collection = {
+            "id": "test-collection",
+            "type": "Collection",
+            "title": "Test Collection",
+            "description": "Test Description",
+            "extent": {
+                "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                "temporal": {"interval": [["2020-01-01T00:00:00Z", None]]},
+            },
+            "license": "MIT",
+            "links": [],
+        }
+
+        try:
+            await txn_client.database.create_collection(collection, refresh=True)
+        except Exception:
+            pass  # Expected to fail
+
+    # Verify error was logged with stack trace
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(error_records) > 0
+    assert any("Error indexing collection" in r.message for r in error_records)
+    assert any(r.exc_info is not None for r in error_records)


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**

- Added update scoped collection endpoint. Preserves parent_ids. [#744](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/744)
- Updated catalogs extension to v0.3.0. [#744](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/744)
- Updated error handling and messaging related to the Catalogs extension. [#744](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/744)

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog