### PR TITLE
fix: use collections index mapping for CQL2 filter in get_all_collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Use collections index mapping when translating CQL2 filters in `get_all_collections()` to fix wrong field paths for collection fields. [#754](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/754)
+
 ### Removed
 
 ### Updated

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -275,7 +275,9 @@ class DatabaseLogic(BaseDatabaseLogic):
             if isinstance(filter, str):
                 filter = orjson.loads(filter)
             # Convert the filter to an Elasticsearch query using the filter module
-            es_query = filter_module.to_es(await self.get_queryables_mapping(), filter)
+            es_query = filter_module.to_es(
+                await self.get_collections_queryables_mapping(), filter
+            )
             query_parts.append(es_query)
 
         # Apply query extension if provided
@@ -439,6 +441,20 @@ class DatabaseLogic(BaseDatabaseLogic):
         )
         return await get_queryables_mapping_shared(
             collection_id=collection_id, mappings=mappings
+        )
+
+    async def get_collections_queryables_mapping(self) -> dict:
+        """Retrieve mapping of Queryables for collection search.
+
+        Used when translating CQL2 filters applied to collection search so that field
+        paths are resolved against the collections index rather than the items index.
+
+        Returns:
+            dict: A dictionary containing the Collection Queryables mappings.
+        """
+        mappings = await self.client.indices.get_mapping(index=COLLECTIONS_INDEX)
+        return await get_queryables_mapping_shared(
+            collection_id=COLLECTIONS_INDEX, mappings=mappings
         )
 
     async def get_all_collection_queryables(self) -> list[dict]:

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -274,7 +274,9 @@ class DatabaseLogic(BaseDatabaseLogic):
             if isinstance(filter, str):
                 filter = orjson.loads(filter)
             # Convert the filter to an OpenSearch query using the filter module
-            es_query = filter_module.to_es(await self.get_queryables_mapping(), filter)
+            es_query = filter_module.to_es(
+                await self.get_collections_queryables_mapping(), filter
+            )
             query_parts.append(es_query)
 
         # Apply query extension if provided
@@ -438,6 +440,20 @@ class DatabaseLogic(BaseDatabaseLogic):
         )
         return await get_queryables_mapping_shared(
             collection_id=collection_id, mappings=mappings
+        )
+
+    async def get_collections_queryables_mapping(self) -> dict:
+        """Retrieve mapping of Queryables for collection search.
+
+        Used when translating CQL2 filters applied to collection search so that field
+        paths are resolved against the collections index rather than the items index.
+
+        Returns:
+            dict: A dictionary containing the Collection Queryables mappings.
+        """
+        mappings = await self.client.indices.get_mapping(index=COLLECTIONS_INDEX)
+        return await get_queryables_mapping_shared(
+            collection_id=COLLECTIONS_INDEX, mappings=mappings
         )
 
     async def get_all_collection_queryables(self) -> list[dict]:

--- a/stac_fastapi/tests/extensions/test_filter.py
+++ b/stac_fastapi/tests/extensions/test_filter.py
@@ -10,6 +10,8 @@ from typing import Callable, Dict
 import pytest
 from httpx import AsyncClient
 
+from ..conftest import create_collection, create_item, refresh_indices
+
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -40,6 +42,73 @@ async def test_filter_extension_collection_link(app_client, load_test_data):
 
     resp = await app_client.delete(f"/collections/{test_collection['id']}")
     assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_collections_search_collection_mapping(
+    app_client, txn_client, load_test_data
+):
+    """Ensure collections filter resolves fields against the collections index mapping.
+
+    Uses 'license' (a root-level collection field mapped as keyword) to create a
+    collision: the non-matching collection has an item whose properties.license equals
+    the target collection's license value. If the filter mistakenly used the items index
+    mapping, it would resolve 'license' to 'properties.license' and could return the
+    wrong collection. With the correct collections mapping, it resolves to the root-level
+    'license' field and returns only the matching collection.
+    """
+    unique_suffix = uuid.uuid4().hex[:8]
+    matching_collection_id = f"filter-license-match-{unique_suffix}"
+    other_collection_id = f"filter-license-other-{unique_suffix}"
+    target_license = f"proprietary-{unique_suffix}"
+
+    matching_collection = copy.deepcopy(load_test_data("test_collection.json"))
+    matching_collection["id"] = matching_collection_id
+    matching_collection["license"] = target_license
+
+    other_collection = copy.deepcopy(load_test_data("test_collection.json"))
+    other_collection["id"] = other_collection_id
+    other_collection["license"] = f"other-license-{unique_suffix}"
+
+    matching_item = copy.deepcopy(load_test_data("test_item.json"))
+    matching_item["id"] = f"filter-license-item-match-{unique_suffix}"
+    matching_item["collection"] = matching_collection_id
+    matching_item["properties"]["license"] = "item-side-license-value"
+
+    other_item = copy.deepcopy(load_test_data("test_item.json"))
+    other_item["id"] = f"filter-license-item-other-{unique_suffix}"
+    other_item["collection"] = other_collection_id
+    other_item["properties"][
+        "license"
+    ] = target_license  # collision: same value as matching collection's license
+
+    await create_collection(txn_client, matching_collection)
+    await create_collection(txn_client, other_collection)
+    await create_item(txn_client, matching_item)
+    await create_item(txn_client, other_item)
+    await refresh_indices(txn_client)
+
+    resp = await app_client.get(
+        "/collections",
+        params={
+            "filter-lang": "cql2-json",
+            "filter": json.dumps(
+                {
+                    "op": "=",
+                    "args": [{"property": "license"}, target_license],
+                }
+            ),
+        },
+    )
+    resp_json = resp.json()
+
+    assert resp.status_code == 200
+    returned_ids = [collection["id"] for collection in resp_json["collections"]]
+    assert matching_collection_id in returned_ids
+    assert other_collection_id not in returned_ids
+
+    await app_client.delete(f"/collections/{matching_collection_id}")
+    await app_client.delete(f"/collections/{other_collection_id}")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

**Description:**

`get_all_collections()`  is calling `get_queryables_mapping()` which reads the items index (items_{collection_id}). Some fields might live at root level for collections and properties for items so the mapping is incorrect.

Add `get_collections_queryables_mapping()` to both backends. It queries COLLECTIONS_INDEX mapping via the same get_queryables_mapping_shared() helper and use it at the filter call site in `get_all_collections()`.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog