### PR TITLE
Fix/add test pagination datetime null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed pagination timeout when searching items with null datetime values (time-range items). Added proper fallback handling for `datetime`, `start_datetime`, and `end_datetime` fields in sort clauses to ensure stable pagination tokens.
+
 ### Removed
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed pagination timeout when searching items with null datetime values (time-range items). Added proper fallback handling for `datetime`, `start_datetime`, and `end_datetime` fields in sort clauses to ensure stable pagination tokens.
+- Fixed pagination timeout when searching items with null datetime values (time-range items). Added proper fallback handling for `datetime`, `start_datetime`, and `end_datetime` fields in sort clauses to ensure stable pagination tokens. [#756](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/756)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This project is built on the following technologies: STAC, stac-fastapi, FastAPI
   - [Interacting with the API](#interacting-with-the-api)
   - [Configure the API](#configure-the-api)
   - [Collection Pagination](#collection-pagination)
+  - [Sorting and Time-Range Items (`datetime: null`)](#sorting-and-time-range-items-datetime-null)
   - [SFEOS Tools CLI](#sfeos-tools-cli)
   - [Redis for navigation](#redis-for-navigation)
   - [Elasticsearch Mappings](#elasticsearch-mappings)
@@ -1217,6 +1218,19 @@ The system uses a precise naming convention:
   ```shell
   curl -X "GET" "http://localhost:8080/collections?limit=1&token=example_token"
   ```
+
+## Sorting and Time-Range Items (`datetime: null`)
+
+Due to a combination of the STAC specification's rules for time-range items and underlying OpenSearch/Elasticsearch pagination constraints, this API implements specific fallback behaviors for sorting.
+
+In STAC, items representing a time range (e.g., a multi-day composite) set their `datetime` field to `null` and provide a `start_datetime` and `end_datetime`. To prevent `search_after` pagination from crashing on these null values, the API assigns missing dates to the extreme past or future depending on your sort direction.
+
+**What this means for your search results:**
+
+* **Default Sort (Newest First):** The API evaluates `datetime` first. All single-snapshot items (which have a `datetime`) will appear chronologically at the top of your search results. All time-range items (which have `datetime: null`) will be grouped together and appear chronologically at the absolute bottom of the search results.
+* **Sorting by `start_datetime`:** If you want to prioritize time-range items, you can explicitly query `?sortby=-start_datetime`. This reverses the behavior: time-range items will sort chronologically at the top of your results, and single-snapshot items (which are missing a start date) will be pushed to the bottom.
+
+**Best Practice:** If your workflow relies on interleaving both single-snapshot and time-range items perfectly by date, we recommend filtering by specific datetime intervals in your query rather than relying strictly on the global sort order.
 
 ## SFEOS Tools CLI
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
@@ -330,9 +330,33 @@ def populate_sort_shared(sortby: list) -> dict[str, dict[str, str]] | None:
         Elasticsearch/OpenSearch for sorting query results. The returned dictionary can be
         directly used in search requests.
         Always includes 'id' as secondary sort to ensure unique pagination tokens.
+        Injects concrete missing fallbacks for temporal fields to prevent search_after
+        pagination crashes on null values.
     """
+    temporal_fields = {"datetime", "start_datetime", "end_datetime"}
+
     if sortby:
-        sort_config = {s.field: {"order": s.direction} for s in sortby}
+        sort_config = {}
+        for s in sortby:
+            field_name = s.field
+            direction = s.direction
+            sort_obj = {"order": direction}
+
+            # Inject concrete fallbacks for temporal fields using epoch milliseconds
+            # to avoid Java NumberFormatException when OpenSearch tries to parse ISO strings
+            if field_name in temporal_fields:
+                if direction == "desc":
+                    # Push missing dates to 1970-01-01 (epoch 0)
+                    sort_obj["missing"] = 0
+                else:
+                    # Push missing dates to 2100-01-01 (epoch 4102444800000)
+                    sort_obj["missing"] = 4102444800000
+            else:
+                # For non-date metadata fields, use _last
+                sort_obj["missing"] = "_last"
+
+            sort_config[field_name] = sort_obj
+
         sort_config.setdefault("id", {"order": "asc"})
         return sort_config
     else:

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
@@ -295,7 +295,14 @@ _ES_INDEX_NAME_UNSUPPORTED_CHARS_TABLE = str.maketrans(
 ITEM_INDICES = f"{ITEMS_INDEX_PREFIX}*,-*kibana*,-{COLLECTIONS_INDEX}*"
 
 DEFAULT_SORT = {
-    "properties.datetime": {"order": "desc"},
+    "properties.datetime": {
+        "order": "desc",
+        "missing": 0,
+    },
+    "properties.start_datetime": {
+        "order": "desc",
+        "missing": 0,
+    },
     "id": {"order": "desc"},
     "collection": {"order": "desc"},
 }
@@ -303,7 +310,7 @@ DEFAULT_SORT = {
 ES_ITEMS_SETTINGS = {
     "index": {
         "sort.field": list(DEFAULT_SORT.keys()),
-        "sort.order": [v["order"] for v in DEFAULT_SORT.values()],
+        "sort.order": [v["order"] for v in DEFAULT_SORT.values()],  # type: ignore
         "mapping.coerce": COERCE_GLOBAL,
     }
 }

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -1181,17 +1181,14 @@ async def test_search_datetime_with_null_datetime_pagination(
         logger.error(f"Failed to refresh indices: {e}")
         pytest.fail(f"Index refresh failed: {e}")
 
-    # Test 1: Exact datetime matching valid-datetime-item and null-datetime-item
     feature_ids = await _search_and_get_ids(
         app_client,
         params={
-            "limit": 1, "collections": [collection_id],
+            "limit": 1,
+            "collections": [collection_id],
         },
     )
-    assert feature_ids == {
-        "null-datetime-item-1",
-        "null-datetime-item-2",
-    }, "Exact datetime search failed"
+    assert len(feature_ids) == 1, "Expected only 1 feature due to limit"
 
     # Cleanup
     try:

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -1135,6 +1135,72 @@ async def test_search_datetime_with_null_datetime(
 
 
 @pytest.mark.asyncio
+async def test_search_datetime_with_null_datetime_pagination(
+    app_client, txn_client, load_test_data
+):
+    if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
+        pytest.skip()
+
+    """Test pagination when properties.datetime is null."""
+    # Setup: Create test collection
+    test_collection = load_test_data("test_collection.json")
+    try:
+        await create_collection(txn_client, collection=test_collection)
+    except Exception as e:
+        logger.error(f"Failed to create collection: {e}")
+        pytest.fail(f"Collection creation failed: {e}")
+
+    base_item = load_test_data("test_item.json")
+    collection_id = base_item["collection"]
+
+    null_dt_item = deepcopy(base_item)
+    null_dt_item["id"] = "null-datetime-item-1"
+    null_dt_item["properties"]["datetime"] = None
+    null_dt_item["properties"]["start_datetime"] = "2020-01-01T00:00:00Z"
+    null_dt_item["properties"]["end_datetime"] = "2020-01-02T00:00:00Z"
+
+    null_dt_item2 = deepcopy(base_item)
+    null_dt_item2["id"] = "null-datetime-item-2"
+    null_dt_item2["properties"]["datetime"] = None
+    null_dt_item2["properties"]["start_datetime"] = "2020-01-02T00:00:00Z"
+    null_dt_item2["properties"]["end_datetime"] = "2020-01-03T00:00:00Z"
+
+    # Create valid items
+    items = [null_dt_item, null_dt_item2]
+    for item in items:
+        try:
+            await create_item(txn_client, item)
+        except Exception as e:
+            logger.error(f"Failed to create item {item['id']}: {e}")
+            pytest.fail(f"Item creation failed: {e}")
+
+    # Refresh indices once
+    try:
+        await refresh_indices(txn_client)
+    except Exception as e:
+        logger.error(f"Failed to refresh indices: {e}")
+        pytest.fail(f"Index refresh failed: {e}")
+
+    # Test 1: Exact datetime matching valid-datetime-item and null-datetime-item
+    feature_ids = await _search_and_get_ids(
+        app_client,
+        params={
+            "limit": 1, "collections": [collection_id],
+        },
+    )
+    assert feature_ids == {
+        "null-datetime-item-1",
+        "null-datetime-item-2",
+    }, "Exact datetime search failed"
+
+    # Cleanup
+    try:
+        await txn_client.delete_collection(test_collection["id"])
+    except Exception as e:
+        logger.warning(f"Failed to delete collection: {e}")
+
+
+@pytest.mark.asyncio
 async def test_hidden_item_true(app_client, txn_client, load_test_data):
     """Test item with hidden=true is filtered out."""
 

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -1141,7 +1141,13 @@ async def test_search_datetime_with_null_datetime_pagination(
     if get_bool_env("ENABLE_DATETIME_INDEX_FILTERING"):
         pytest.skip()
 
-    """Test pagination when properties.datetime is null."""
+    """Test pagination when properties.datetime is null.
+
+    This test verifies that:
+    1. Single-snapshot items (with datetime) appear first in descending sort
+    2. Time-range items (with datetime: null) are pushed to the end via fallback
+    3. Pagination correctly separates them across pages
+    """
     # Setup: Create test collection
     test_collection = load_test_data("test_collection.json")
     try:
@@ -1153,20 +1159,26 @@ async def test_search_datetime_with_null_datetime_pagination(
     base_item = load_test_data("test_item.json")
     collection_id = base_item["collection"]
 
-    null_dt_item = deepcopy(base_item)
-    null_dt_item["id"] = "null-datetime-item-1"
-    null_dt_item["properties"]["datetime"] = None
-    null_dt_item["properties"]["start_datetime"] = "2020-01-01T00:00:00Z"
-    null_dt_item["properties"]["end_datetime"] = "2020-01-02T00:00:00Z"
+    # Create a recent single-snapshot item (should appear first in desc sort)
+    snapshot_item = deepcopy(base_item)
+    snapshot_item["id"] = "test-snapshot-item-2026"
+    snapshot_item["properties"]["datetime"] = "2026-01-15T12:00:00Z"
+
+    # Create time-range items with null datetime (should be pushed to end)
+    null_dt_item1 = deepcopy(base_item)
+    null_dt_item1["id"] = "test-time-range-item-2020-01"
+    null_dt_item1["properties"]["datetime"] = None
+    null_dt_item1["properties"]["start_datetime"] = "2020-01-01T00:00:00Z"
+    null_dt_item1["properties"]["end_datetime"] = "2020-01-02T00:00:00Z"
 
     null_dt_item2 = deepcopy(base_item)
-    null_dt_item2["id"] = "null-datetime-item-2"
+    null_dt_item2["id"] = "test-time-range-item-2020-02"
     null_dt_item2["properties"]["datetime"] = None
     null_dt_item2["properties"]["start_datetime"] = "2020-01-02T00:00:00Z"
     null_dt_item2["properties"]["end_datetime"] = "2020-01-03T00:00:00Z"
 
-    # Create valid items
-    items = [null_dt_item, null_dt_item2]
+    # Create all items
+    items = [snapshot_item, null_dt_item1, null_dt_item2]
     for item in items:
         try:
             await create_item(txn_client, item)
@@ -1181,14 +1193,63 @@ async def test_search_datetime_with_null_datetime_pagination(
         logger.error(f"Failed to refresh indices: {e}")
         pytest.fail(f"Index refresh failed: {e}")
 
-    feature_ids = await _search_and_get_ids(
-        app_client,
+    # PAGE 1: Fetch with limit=1, should get the snapshot item (newest first)
+    response = await app_client.get(
+        "/search",
         params={
             "limit": 1,
-            "collections": [collection_id],
+            "collections": collection_id,
         },
     )
-    assert len(feature_ids) == 1, "Expected only 1 feature due to limit"
+    assert response.status_code == 200
+    page1_data = response.json()
+    assert len(page1_data["features"]) == 1
+
+    # ASSERTION: The 2026 single-snapshot item MUST be first
+    assert (
+        page1_data["features"][0]["id"] == "test-snapshot-item-2026"
+    ), "Snapshot item with datetime should appear first in descending sort"
+
+    # Get pagination token for next page
+    next_token = None
+    for link in page1_data.get("links", []):
+        if link.get("rel") == "next":
+            # For GET requests, token is in the href URL
+            if link.get("method") == "GET" or "href" in link:
+                from urllib.parse import parse_qs, urlparse
+
+                parsed_url = urlparse(link.get("href", ""))
+                query_params = parse_qs(parsed_url.query)
+                next_token = query_params.get("token", [None])[0]
+            # For POST requests, token is in the body
+            else:
+                next_token = link.get("body", {}).get("token")
+            break
+
+    assert next_token is not None, "Expected next token for pagination"
+
+    # PAGE 2: Fetch next page with token
+    page2_response = await app_client.get(
+        "/search",
+        params={
+            "limit": 1,
+            "collections": collection_id,
+            "token": next_token,
+        },
+    )
+    assert page2_response.status_code == 200
+    page2_data = page2_response.json()
+    assert len(page2_data["features"]) == 1
+
+    # ASSERTION: A time-range item was successfully pushed to page 2
+    page2_item_id = page2_data["features"][0]["id"]
+    assert page2_item_id in [
+        "test-time-range-item-2020-01",
+        "test-time-range-item-2020-02",
+    ], (
+        "Time-range item with datetime: null should appear on page 2 "
+        "due to fallback to epoch 0 (ancient past)"
+    )
 
     # Cleanup
     try:


### PR DESCRIPTION
**Related Issue(s):**

- #755 

**Description:**

- Fixed pagination timeout when searching items with null datetime values (time-range items). Added proper fallback handling for `datetime`, `start_datetime`, and `end_datetime` fields in sort clauses to ensure stable pagination tokens.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog