### PR TITLE
Release v6.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Updated
 
-## [v6.18.0] - 2026-06-06
+## [v6.17.1] - 2026-06-06
 
 ### Fixed
 
@@ -909,8 +909,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use genexp in execute_search and get_all_collections to return results.
 - Added db_to_stac serializer to item_collection method in core.py.
 
-[Unreleased]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.18.0...main
-[v6.18.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.17.0...v6.18.0
+[Unreleased]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.17.1...main
+[v6.17.1]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.17.0...v6.17.1
 [v6.17.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.16.0...v6.17.0
 [v6.16.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.15.0...v6.16.0
 [v6.15.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.14.1...v6.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Use collections index mapping when translating CQL2 filters in `get_all_collections()` to fix wrong field paths for collection fields. [#754](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/754)
-- Fixed pagination timeout when searching items with null datetime values (time-range items). Added proper fallback handling for `datetime`, `start_datetime`, and `end_datetime` fields in sort clauses to ensure stable pagination tokens. [#756](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/756)
-
 ### Removed
 
 ### Updated
+
+## [v6.18.0] - 2026-06-06
+
+### Fixed
+
+- Use collections index mapping when translating CQL2 filters in `get_all_collections()` to fix wrong field paths for collection fields. [#754](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/754)
+- Fixed pagination timeout when searching items with null datetime values (time-range items). Added proper fallback handling for `datetime`, `start_datetime`, and `end_datetime` fields in sort clauses to ensure stable pagination tokens. [#756](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/756)
 
 ## [v6.17.0] - 2026-05-25
 
@@ -905,7 +909,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use genexp in execute_search and get_all_collections to return results.
 - Added db_to_stac serializer to item_collection method in core.py.
 
-[Unreleased]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.17.0...main
+[Unreleased]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.18.0...main
+[v6.18.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.17.0...v6.18.0
 [v6.17.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.16.0...v6.17.0
 [v6.16.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.15.0...v6.16.0
 [v6.15.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.14.1...v6.15.0

--- a/stac_fastapi/core/stac_fastapi/core/version.py
+++ b/stac_fastapi/core/stac_fastapi/core/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.17.0"
+__version__ = "6.18.0"

--- a/stac_fastapi/core/stac_fastapi/core/version.py
+++ b/stac_fastapi/core/stac_fastapi/core/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.18.0"
+__version__ = "6.17.1"

--- a/stac_fastapi/elasticsearch/pyproject.toml
+++ b/stac_fastapi/elasticsearch/pyproject.toml
@@ -28,8 +28,8 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "stac-fastapi-core==6.18.0",
-    "sfeos-helpers==6.18.0",
+    "stac-fastapi-core==6.17.1",
+    "sfeos-helpers==6.17.1",
     "elasticsearch[async]>=8.19.1,<9.5.0",
 ]
 
@@ -38,7 +38,7 @@ Homepage = "https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch"
 
 [project.optional-dependencies]
 catalogs = [
-    "stac-fastapi-core[catalogs]==6.18.0",
+    "stac-fastapi-core[catalogs]==6.17.1",
 ]
 dev = [
     "pytest>=8,<10",
@@ -49,8 +49,8 @@ dev = [
     "httpx>=0.24.0,<0.29.0",
     "redis>=6.4,<8.1",
     "retry~=0.9.2",
-    "stac-fastapi-core[sentry]==6.18.0",
-    "stac-fastapi-core[redis]==6.18.0",
+    "stac-fastapi-core[sentry]==6.17.1",
+    "stac-fastapi-core[redis]==6.17.1",
 ]
 docs = [
     "mkdocs>=1.4,<1.7",
@@ -60,7 +60,7 @@ docs = [
     "retry~=0.9.2",
 ]
 redis = [
-    "stac-fastapi-core[redis]==6.18.0",
+    "stac-fastapi-core[redis]==6.17.1",
 ]
 server = [
     "uvicorn[standard]>=0.23,<0.50",

--- a/stac_fastapi/elasticsearch/pyproject.toml
+++ b/stac_fastapi/elasticsearch/pyproject.toml
@@ -28,8 +28,8 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "stac-fastapi-core==6.17.0",
-    "sfeos-helpers==6.17.0",
+    "stac-fastapi-core==6.18.0",
+    "sfeos-helpers==6.18.0",
     "elasticsearch[async]>=8.19.1,<9.5.0",
 ]
 
@@ -38,7 +38,7 @@ Homepage = "https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch"
 
 [project.optional-dependencies]
 catalogs = [
-    "stac-fastapi-core[catalogs]==6.17.0",
+    "stac-fastapi-core[catalogs]==6.18.0",
 ]
 dev = [
     "pytest>=8,<10",
@@ -49,8 +49,8 @@ dev = [
     "httpx>=0.24.0,<0.29.0",
     "redis>=6.4,<8.1",
     "retry~=0.9.2",
-    "stac-fastapi-core[sentry]==6.17.0",
-    "stac-fastapi-core[redis]==6.17.0",
+    "stac-fastapi-core[sentry]==6.18.0",
+    "stac-fastapi-core[redis]==6.18.0",
 ]
 docs = [
     "mkdocs>=1.4,<1.7",
@@ -60,7 +60,7 @@ docs = [
     "retry~=0.9.2",
 ]
 redis = [
-    "stac-fastapi-core[redis]==6.17.0",
+    "stac-fastapi-core[redis]==6.18.0",
 ]
 server = [
     "uvicorn[standard]>=0.23,<0.50",

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -272,7 +272,7 @@ items_get_request_model = create_request_model(
 app_config = {
     "title": os.getenv("STAC_FASTAPI_TITLE", "stac-fastapi-elasticsearch"),
     "description": os.getenv("STAC_FASTAPI_DESCRIPTION", "stac-fastapi-elasticsearch"),
-    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.17.0"),
+    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.18.0"),
     "settings": settings,
     "extensions": extensions,
     "client": CoreClient(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -272,7 +272,7 @@ items_get_request_model = create_request_model(
 app_config = {
     "title": os.getenv("STAC_FASTAPI_TITLE", "stac-fastapi-elasticsearch"),
     "description": os.getenv("STAC_FASTAPI_DESCRIPTION", "stac-fastapi-elasticsearch"),
-    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.18.0"),
+    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.17.1"),
     "settings": settings,
     "extensions": extensions,
     "client": CoreClient(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.17.0"
+__version__ = "6.18.0"

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.18.0"
+__version__ = "6.17.1"

--- a/stac_fastapi/opensearch/pyproject.toml
+++ b/stac_fastapi/opensearch/pyproject.toml
@@ -28,8 +28,8 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "stac-fastapi-core==6.18.0",
-    "sfeos-helpers==6.18.0",
+    "stac-fastapi-core==6.17.1",
+    "sfeos-helpers==6.17.1",
     "opensearch-py>=2.8,<3.3",
     "opensearch-py[async]>=2.8,<3.3",
 ]
@@ -39,7 +39,7 @@ Homepage = "https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch"
 
 [project.optional-dependencies]
 catalogs = [
-    "stac-fastapi-core[catalogs]==6.18.0",
+    "stac-fastapi-core[catalogs]==6.17.1",
 ]
 dev = [
     "pytest>=8,<10",
@@ -50,8 +50,8 @@ dev = [
     "httpx>=0.24.0,<0.29.0",
     "redis>=6.4,<8.1",
     "retry~=0.9.2",
-    "stac-fastapi-core[sentry]==6.18.0",
-    "stac-fastapi-core[redis]==6.18.0",
+    "stac-fastapi-core[sentry]==6.17.1",
+    "stac-fastapi-core[redis]==6.17.1",
 ]
 docs = [
     "mkdocs>=1.4,<1.7",
@@ -59,7 +59,7 @@ docs = [
     "pdocs~=1.2.0",
 ]
 redis = [
-    "stac-fastapi-core[redis]==6.18.0",
+    "stac-fastapi-core[redis]==6.17.1",
 ]
 server = [
     "uvicorn[standard]>=0.23,<0.50",

--- a/stac_fastapi/opensearch/pyproject.toml
+++ b/stac_fastapi/opensearch/pyproject.toml
@@ -28,8 +28,8 @@ keywords = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "stac-fastapi-core==6.17.0",
-    "sfeos-helpers==6.17.0",
+    "stac-fastapi-core==6.18.0",
+    "sfeos-helpers==6.18.0",
     "opensearch-py>=2.8,<3.3",
     "opensearch-py[async]>=2.8,<3.3",
 ]
@@ -39,7 +39,7 @@ Homepage = "https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch"
 
 [project.optional-dependencies]
 catalogs = [
-    "stac-fastapi-core[catalogs]==6.17.0",
+    "stac-fastapi-core[catalogs]==6.18.0",
 ]
 dev = [
     "pytest>=8,<10",
@@ -50,8 +50,8 @@ dev = [
     "httpx>=0.24.0,<0.29.0",
     "redis>=6.4,<8.1",
     "retry~=0.9.2",
-    "stac-fastapi-core[sentry]==6.17.0",
-    "stac-fastapi-core[redis]==6.17.0",
+    "stac-fastapi-core[sentry]==6.18.0",
+    "stac-fastapi-core[redis]==6.18.0",
 ]
 docs = [
     "mkdocs>=1.4,<1.7",
@@ -59,7 +59,7 @@ docs = [
     "pdocs~=1.2.0",
 ]
 redis = [
-    "stac-fastapi-core[redis]==6.17.0",
+    "stac-fastapi-core[redis]==6.18.0",
 ]
 server = [
     "uvicorn[standard]>=0.23,<0.50",

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -271,7 +271,7 @@ items_get_request_model = create_request_model(
 app_config = {
     "title": os.getenv("STAC_FASTAPI_TITLE", "stac-fastapi-opensearch"),
     "description": os.getenv("STAC_FASTAPI_DESCRIPTION", "stac-fastapi-opensearch"),
-    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.18.0"),
+    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.17.1"),
     "settings": settings,
     "extensions": extensions,
     "client": CoreClient(

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -271,7 +271,7 @@ items_get_request_model = create_request_model(
 app_config = {
     "title": os.getenv("STAC_FASTAPI_TITLE", "stac-fastapi-opensearch"),
     "description": os.getenv("STAC_FASTAPI_DESCRIPTION", "stac-fastapi-opensearch"),
-    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.17.0"),
+    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.18.0"),
     "settings": settings,
     "extensions": extensions,
     "client": CoreClient(

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.17.0"
+__version__ = "6.18.0"

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.18.0"
+__version__ = "6.17.1"

--- a/stac_fastapi/sfeos_helpers/pyproject.toml
+++ b/stac_fastapi/sfeos_helpers/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
 dynamic = ["version"]
 dependencies = [
     "tenacity~=9.1.2",
-    "stac-fastapi.core==6.18.0",
+    "stac-fastapi.core==6.17.1",
 ]
 
 [project.optional-dependencies]

--- a/stac_fastapi/sfeos_helpers/pyproject.toml
+++ b/stac_fastapi/sfeos_helpers/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
 dynamic = ["version"]
 dependencies = [
     "tenacity~=9.1.2",
-    "stac-fastapi.core==6.17.0",
+    "stac-fastapi.core==6.18.0",
 ]
 
 [project.optional-dependencies]

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.17.0"
+__version__ = "6.18.0"

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "6.18.0"
+__version__ = "6.17.1"


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**

- Use collections index mapping when translating CQL2 filters in `get_all_collections()` to fix wrong field paths for collection fields. [#754](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/754)
- Fixed pagination timeout when searching items with null datetime values (time-range items). Added proper fallback handling for `datetime`, `start_datetime`, and `end_datetime` fields in sort clauses to ensure stable pagination tokens. [#756](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/756)

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog