### PR TITLE
add catalogs search extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Updated
 
+- Updated `stac-fastapi-catalogs-extension` to `v0.5.0`. [#783](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/783)
+
 ## [v6.18.0] - 2025-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added `CatalogsSearchExtension` support to enable scoped search within catalogs and their descendants. Catalog search uses BFS DAG traversal to discover all descendant collections and enforces scope with 403 Forbidden when users request out-of-scope collections. Supports all search parameters (datetime, intersects, sortby, limit, token) via pass-through to core search logic. [#782](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/782)
+
 ### Changed
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-elasticsearch: image-es-os
 
 .PHONY: test-elasticsearch-catalogs
 test-elasticsearch-catalogs: image-es-os
-	-$(run_es) /bin/bash -c 'export && ./scripts/wait-for-it-es.sh elasticsearch:9200 && cd stac_fastapi/tests/ && pytest extensions/test_catalogs.py -v'
+	-$(run_es) /bin/bash -c 'export && ./scripts/wait-for-it-es.sh elasticsearch:9200 && cd stac_fastapi/tests/ && pytest extensions/test_catalogs.py -v && pytest extensions/test_catalogs_search.py -v'
 	docker compose down
 
 .PHONY: test-elasticsearch-validation

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following organizations have contributed time and/or funding to support the 
 
 ## Latest News
 
+- **06/21/2026:** 🔍 **Catalogs Search Extension!** Search items across entire catalog hierarchies with the new `/catalogs/{catalog_id}/search` endpoint. This powerful feature uses **BFS recursive DAG traversal** to automatically discover all descendant collections within a catalog's subtree (including nested sub-catalogs) and searches items across all of them. Enforces strict scope boundaries with 403 Forbidden for out-of-scope collection requests. Supports all standard STAC search parameters (spatial filtering, temporal filtering, free-text search, CQL2 filtering, sorting, and pagination). Perfect for scoped item discovery within organizational hierarchies! Implements the [STAC API - Multi-Tenant Catalogs Scoped Search](https://github.com/StacLabs/multi-tenant-catalogs#scoped-search-recursive-traversal) specification.
 - **06/14/2026:** 🛡️ **Native STAC & Topology Validation in v6.18.0!** SFEOS now features built-in, strict STAC schema validation via the Python `stac-validator` package (available via the new `[validator]` install extra). We've also introduced a blazing-fast, pure-Python spatial topology checker to protect your database from invalid coordinates and uncut antimeridian polygons. To support massive ingestion workloads, these powerful new firewalls include configurable chunking (`MAX_BATCH_SIZE`), fail-fast error thresholds, and Redis queue deference controls (`VALIDATE_BEFORE_QUEUE`). Finally, multi-tenant deployments gain a security boost with the new `HIDE_ALTERNATE_PARENTS` poly-hierarchy privacy toggle. 🙏 Huge thanks to **CloudFerro** for their continued sponsorship of these robust new features!
 - **03/19/2026: SKOS to STAC Ingestion Demo.** 📓 Check out the interactive [SKOS-catalogs-ingestion-demo.ipynb](https://github.com/StacLabs/sfeos-tools/blob/main/demo-notebooks/SKOS-catalogs-ingestion-demo.ipynb) notebook! This tutorial demonstrates automated semantic ingestion from SKOS/RDF-XML files into hierarchical STAC catalogs, showcasing poly-hierarchy, contextual breadcrumbs, and data safety features of the Multi-Tenant Catalogs extension. Thanks to support from CloudFerro! 
 - **01/11/2026: Hierarchical Catalog Support.** Sub-catalogs are now fully supported! Catalogs can now contain other catalogs for unlimited nesting levels. This enables complex organizational hierarchies with multi-parent support for both catalogs and collections.
@@ -94,6 +95,7 @@ This project is built on the following technologies: STAC, stac-fastapi, FastAPI
   - [Table of Contents](#table-of-contents)
   - [Collection Search Extensions](#collection-search-extensions)
   - [Catalogs Route](#catalogs-route)
+  - [Catalogs Search Extension](#catalogs-search-extension)
   - [Documentation & Resources](#documentation--resources)
   - [SFEOS STAC Viewer](#sfeos-stac-viewer)
   - [Package Structure](#package-structure)
@@ -578,6 +580,159 @@ You can discover it as a child of forestry via:
 Because you are linking the node (the Catalog), the entire sub-tree attached to that node is automatically shared. If sentinel-2 contains millions of items and sub-catalogs, they are all instantly visible under the new forestry parent without needing to re-link individual items.
 
 > **Configuration**: The catalogs route can be enabled or disabled by setting the `ENABLE_CATALOGS_ROUTE` environment variable to `true` or `false`. By default, this endpoint is **disabled**.
+
+## Catalogs Search Extension
+
+The **Catalogs Search Extension** enables searching for items across an entire catalog's subtree, including all sub-catalogs and their collections. This is similar to the global items search, but scoped to a specific catalog hierarchy.
+
+This implementation follows the [STAC API - Multi-Tenant Catalogs Scoped Search (Recursive Traversal)](https://github.com/StacLabs/multi-tenant-catalogs#scoped-search-recursive-traversal) specification, which defines how to safely search items within catalog hierarchies while enforcing scope boundaries.
+
+### Overview
+
+The catalogs search extension provides a powerful way to discover items within organizational hierarchies without needing to know which specific collections contain them. It automatically traverses the catalog DAG (Directed Acyclic Graph) to find all descendant collections and searches items across all of them.
+
+### Key Features
+
+- **Subtree Search**: Search items across a catalog and all its sub-catalogs
+- **Rich Query Support**: All standard STAC search parameters are supported
+- **Spatial Filtering**: Filter items by bounding box
+- **Temporal Filtering**: Filter items by datetime range
+- **Free-Text Search**: Search item properties with the `q` parameter
+- **CQL2 Filtering**: Advanced structured filtering with CQL2 expressions
+- **Sorting**: Sort results by any indexed field
+- **Pagination**: Navigate large result sets with limit and token parameters
+- **DAG Traversal**: Automatic breadth-first search through catalog hierarchies
+- **Scope Enforcement**: Requests are automatically restricted to the catalog's descendant collections
+
+### Endpoints
+
+**Search Endpoints:**
+
+- **GET `/catalogs/{catalog_id}/search`**: Search items using query parameters
+- **POST `/catalogs/{catalog_id}/search`**: Search items using a JSON request body (supports large payloads)
+
+### Supported Parameters
+
+The catalogs search endpoints support all standard STAC search parameters:
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| `collections` | array | Limit search to specific collections within the catalog | `?collections=sentinel-2,landsat-9` |
+| `ids` | array | Search for specific item IDs | `?ids=item-1,item-2` |
+| `bbox` | array | Bounding box filter `[minx,miny,maxx,maxy]` | `?bbox=-10,35,40,70` |
+| `intersects` | string | GeoJSON geometry filter | `?intersects={"type":"Point","coordinates":[0,0]}` |
+| `datetime` | string | Datetime range filter | `?datetime=2020-01-01T00:00:00Z/2020-12-31T23:59:59Z` |
+| `q` | string | Free-text search across item properties | `?q=landsat` |
+| `filter` | string | CQL2 filter expression (JSON or text) | `?filter={"op":"=","args":[{"property":"eo:bands"},1]}` |
+| `filter-lang` | string | CQL2 format: `cql2-json` or `cql2-text` | `?filter-lang=cql2-json` |
+| `sortby` | string | Sort results by field | `?sortby=-datetime` |
+| `fields` | string | Select specific fields to return | `?fields=id,properties.datetime` |
+| `limit` | integer | Maximum results per page (default: 10) | `?limit=50` |
+| `token` | string | Pagination token for next page | `?token=<pagination-token>` |
+
+### How It Works
+
+The catalogs search extension uses a **breadth-first search (BFS) DAG traversal** to discover all descendant collections:
+
+1. **Catalog Validation**: Verifies the requested catalog exists
+2. **DAG Traversal**: Performs BFS through the catalog hierarchy using the `parent_ids` field
+   - Starts from the requested catalog
+   - Finds all direct children (both sub-catalogs and collections)
+   - Recursively traverses sub-catalogs to find their children
+   - Collects all descendant collections
+3. **Scope Enforcement**: Restricts search to only the descendant collections
+4. **Query Delegation**: Passes the scoped search to the core search engine
+5. **Result Return**: Returns items matching the search criteria
+
+### Usage Examples
+
+```bash
+# Search all items in a catalog
+curl "http://localhost:8081/catalogs/earth-observation/search?q=landsat"
+
+# Search with spatial and temporal filters
+curl "http://localhost:8081/catalogs/earth-observation/search?bbox=-180,-90,180,90&datetime=2020-01-01T00:00:00Z/2020-12-31T23:59:59Z"
+
+# Search specific collections within a catalog
+curl "http://localhost:8081/catalogs/earth-observation/search?collections=sentinel-2,landsat-9&limit=50"
+
+# Advanced CQL2 filtering
+curl "http://localhost:8081/catalogs/earth-observation/search?filter=eo:cloud_cover%3C20&filter-lang=cql2-text"
+
+# Free-text search with sorting
+curl "http://localhost:8081/catalogs/earth-observation/search?q=forest&sortby=-datetime"
+
+# POST request with complex search (supports large payloads)
+curl -X POST "http://localhost:8081/catalogs/earth-observation/search" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "bbox": [-180, -90, 180, 90],
+    "datetime": "2020-01-01T00:00:00Z/2020-12-31T23:59:59Z",
+    "filter": {
+      "op": "and",
+      "args": [
+        {"op": "<", "args": [{"property": "eo:cloud_cover"}, 20]},
+        {"op": "=", "args": [{"property": "platform"}, "sentinel-2"]}
+      ]
+    },
+    "limit": 100
+  }'
+
+# Pagination example
+curl "http://localhost:8081/catalogs/earth-observation/search?limit=10"
+# Use the returned 'next' link token for the next page
+curl "http://localhost:8081/catalogs/earth-observation/search?limit=10&token=<token-from-previous-response>"
+```
+
+### Scope Enforcement
+
+The catalogs search extension enforces strict scope boundaries as required by the [STAC API - Multi-Tenant Catalogs specification](https://github.com/StacLabs/multi-tenant-catalogs#scoped-search-recursive-traversal):
+
+- **Allowed**: Search any collections within the catalog's subtree
+- **Allowed**: Specify a subset of descendant collections to search
+- **Blocked**: Request collections outside the catalog's scope (returns 403 Forbidden)
+- **Empty Catalog**: Returns empty results if the catalog has no descendant collections
+
+**Scope Enforcement Rules:**
+- The API computes the intersection of user-requested collections and the catalog's allowed descendant collections
+- Any requested collections outside the descendant tree are rejected with a 403 Forbidden error
+- Users cannot escape the catalog boundary through collection parameters
+- All items returned are guaranteed to be within the catalog's hierarchy
+
+Example of scope enforcement:
+
+```bash
+# This works - sentinel-2 is in earth-observation's subtree
+curl "http://localhost:8081/catalogs/earth-observation/search?collections=sentinel-2"
+
+# This fails - landsat-archive is not in earth-observation's subtree
+curl "http://localhost:8081/catalogs/earth-observation/search?collections=landsat-archive"
+# Response: 403 Forbidden - "Requested collections are outside the scope of this catalog."
+```
+
+### Performance Considerations
+
+- **DAG Traversal**: The BFS traversal is optimized with a 10,000 result limit per query level. Large hierarchies with more than 10,000 direct children at any level will log a warning.
+- **Caching**: For frequently accessed catalogs, consider caching the descendant collection list at the application level
+- **Index Size**: Searching large catalogs with millions of items may require tuning Elasticsearch/OpenSearch settings
+- **Pagination**: Use pagination tokens for efficient navigation through large result sets
+
+### Conformance Classes
+
+When the catalogs search extension is enabled, SFEOS advertises the following conformance class:
+
+- **`https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/search`** - Indicates support for scoped search endpoints with recursive traversal through catalog hierarchies
+
+This conformance class is automatically advertised in the API's `/conformance` endpoint when `ENABLE_CATALOGS_ROUTE=true`.
+
+### Configuration
+
+The catalogs search extension is automatically enabled when the catalogs route is enabled:
+
+```bash
+# Enable catalogs route (which includes search)
+export ENABLE_CATALOGS_ROUTE=true
+```
 
 ## Package Structure
 

--- a/stac_fastapi/core/pyproject.toml
+++ b/stac_fastapi/core/pyproject.toml
@@ -54,7 +54,7 @@ sentry = [
     "sentry-sdk>=2.49,<2.63",
 ]
 catalogs = [
-    "stac-fastapi-catalogs-extension==0.4.0",
+    "stac-fastapi-catalogs-extension==0.5.0",
 ]
 validator = [
     "stac-valid~=4.2.2"

--- a/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
+++ b/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
@@ -2,11 +2,14 @@
 
 import logging
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, List, Literal, Set
 
 import attr
-from fastapi import Request
-from stac_fastapi_catalogs_extension.client import AsyncBaseCatalogsClient
+from fastapi import HTTPException, Request
+from stac_fastapi_catalogs_extension.client import (
+    AsyncBaseCatalogsClient,
+    AsyncCatalogsSearchClient,
+)
 from stac_fastapi_catalogs_extension.types import Catalogs, Children, ObjectUri
 from stac_pydantic.api.collections import Collections
 from stac_pydantic.catalog import Catalog
@@ -22,22 +25,24 @@ from stac_fastapi.core.serializers import (
     ItemSerializer,
 )
 from stac_fastapi.types.errors import NotFoundError
+from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest
 
 logger = logging.getLogger(__name__)
 
 
 @attr.s
-class CatalogsClient(AsyncBaseCatalogsClient):
+class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
     """Catalogs client implementation for the multi-tenant catalogs extension.
 
-    This client implements the AsyncBaseCatalogsClient interface and delegates
-    to the database layer for all catalog operations.
+    This client implements the AsyncBaseCatalogsClient and AsyncCatalogsSearchClient
+    interfaces and delegates to the database layer for all catalog operations.
     """
 
     database: BaseDatabaseLogic = attr.ib()
     catalog_serializer: CatalogSerializer = attr.ib(default=CatalogSerializer)
     collection_serializer: CollectionSerializer = attr.ib(default=CollectionSerializer)
     item_serializer: ItemSerializer = attr.ib(default=ItemSerializer)
+    core_client: Any = attr.ib(default=None)
 
     def _get_base_url(self, request: Request | None) -> str:
         """Extract base URL from request with sensible default.
@@ -1453,3 +1458,150 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                 exc_info=True,
             )
             raise
+
+    async def get_all_descendant_collections(
+        self, catalog_id: str, request: Request | None = None, **kwargs
+    ) -> List[str]:
+        """BFS DAG crawl to find all descendant collections using parent_ids field.
+
+        Args:
+            catalog_id: The root catalog ID to start traversal from.
+            request: FastAPI request object.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            List of all descendant collection IDs.
+        """
+        visited_catalogs: Set[str] = {catalog_id}
+        queue: List[str] = [catalog_id]
+        descendant_collections: Set[str] = set()
+
+        while queue:
+            # 1. Get Collections with parent_ids matching current queue
+            coll_query = {
+                "query": {"terms": {"parent_ids": queue}},
+                "_source": ["id"],
+                "size": 10000,
+            }
+            try:
+                coll_resp = await self.database.database.search(
+                    index=self.database.collection_table, body=coll_query
+                )
+                for hit in coll_resp.get("hits", {}).get("hits", []):
+                    descendant_collections.add(hit["_source"]["id"])
+            except Exception as e:
+                logger.warning(
+                    f"Error fetching collections for catalog {catalog_id}: {e}"
+                )
+
+            # 2. Get Sub-Catalogs with parent_ids matching current queue
+            cat_query = {
+                "query": {"terms": {"parent_ids": queue}},
+                "_source": ["id"],
+                "size": 10000,
+            }
+            try:
+                cat_resp = await self.database.database.search(
+                    index=self.database.catalog_table, body=cat_query
+                )
+                next_queue = []
+                for hit in cat_resp.get("hits", {}).get("hits", []):
+                    child_cat_id = hit["_source"]["id"]
+                    if child_cat_id not in visited_catalogs:
+                        visited_catalogs.add(child_cat_id)
+                        next_queue.append(child_cat_id)
+                queue = next_queue
+            except Exception as e:
+                logger.warning(
+                    f"Error fetching sub-catalogs for catalog {catalog_id}: {e}"
+                )
+                queue = []
+
+        return list(descendant_collections)
+
+    async def catalog_search_post(
+        self,
+        catalog_id: str,
+        search_request: BaseSearchPostRequest,
+        request: Request | None = None,
+        **kwargs,
+    ) -> ItemCollection | Response:
+        """Search items within a catalog and its descendants.
+
+        Args:
+            catalog_id: The catalog ID to search within.
+            search_request: The search request parameters.
+            request: FastAPI request object.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            ItemCollection with matching items.
+
+        Raises:
+            HTTPException: If requested collections are outside catalog scope.
+        """
+        # Get all descendant collections for this catalog
+        allowed_collections = await self.get_all_descendant_collections(
+            catalog_id, request
+        )
+
+        # If no collections, return empty result
+        if not allowed_collections:
+            return ItemCollection(type="FeatureCollection", features=[], links=[])
+
+        # Intersect requested collections with allowed collections
+        if search_request.collections:
+            intersected = list(
+                set(search_request.collections) & set(allowed_collections)
+            )
+            if not intersected:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Requested collections are outside the scope of this catalog.",
+                )
+            search_request.collections = intersected
+        else:
+            # No specific collections requested, use all descendant collections
+            search_request.collections = allowed_collections
+
+        # Hand off to core search logic
+        if self.core_client:
+            return await self.core_client.post_search(
+                search_request=search_request, request=request
+            )
+        else:
+            # Fallback if core_client not set
+            return ItemCollection(type="FeatureCollection", features=[], links=[])
+
+    async def catalog_search_get(
+        self,
+        catalog_id: str,
+        request: Request | None = None,
+        **kwargs,
+    ) -> ItemCollection | Response:
+        """Search items within a catalog using GET parameters.
+
+        Args:
+            catalog_id: The catalog ID to search within.
+            request: FastAPI request object.
+            **kwargs: Search parameters from GET query string.
+
+        Returns:
+            ItemCollection with matching items.
+        """
+        # Build GET model from kwargs
+        search_request = BaseSearchGetRequest(**kwargs)
+        # Convert GET request to POST for internal processing
+        post_request = BaseSearchPostRequest(
+            collections=search_request.collections,
+            bbox=search_request.bbox,
+            datetime=search_request.datetime,
+            limit=search_request.limit,
+            query=search_request.query if hasattr(search_request, "query") else None,
+            filter=search_request.filter if hasattr(search_request, "filter") else None,
+            sortby=search_request.sortby if hasattr(search_request, "sortby") else None,
+            fields=search_request.fields if hasattr(search_request, "fields") else None,
+        )
+        return await self.catalog_search_post(
+            catalog_id, post_request, request, **kwargs
+        )

--- a/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
+++ b/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
@@ -1471,65 +1471,58 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
 
         Returns:
             List of all descendant collection IDs.
+
+        Raises:
+            NotFoundError: If the catalog does not exist.
         """
+        # Validate that the catalog exists
+        try:
+            await self.database.find_catalog(catalog_id)
+        except NotFoundError:
+            raise
+
         visited_catalogs: Set[str] = {catalog_id}
         queue: List[str] = [catalog_id]
         descendant_collections: Set[str] = set()
 
+        # SFEOS uses the 'collections' index for both catalogs and collections
+        index_name = "collections"
+
         while queue:
-            # 1. Get Collections with parent_ids matching current queue
-            coll_query = {
+            # We can fetch both Sub-Catalogs AND Collections in a single query!
+            query = {
                 "query": {"terms": {"parent_ids": queue}},
-                "_source": ["id"],
+                "_source": ["id", "type"],
                 "size": 10000,
             }
             try:
-                coll_resp = await self.database.database.search(
-                    index=self.database.collection_table, body=coll_query
-                )
-                hits = coll_resp.get("hits", {}).get("hits", [])
+                resp = await self.database.client.search(index=index_name, body=query)
+                hits = resp.get("hits", {}).get("hits", [])
 
                 if len(hits) == 10000:
                     logger.warning(
-                        f"DAG traversal hit 10k result limit on collections for catalog {catalog_id}. "
-                        "Some descendants may be truncated."
-                    )
-
-                for hit in hits:
-                    descendant_collections.add(hit["_source"]["id"])
-            except Exception as e:
-                logger.warning(
-                    f"Error fetching collections for catalog {catalog_id}: {e}"
-                )
-
-            # 2. Get Sub-Catalogs with parent_ids matching current queue
-            cat_query = {
-                "query": {"terms": {"parent_ids": queue}},
-                "_source": ["id"],
-                "size": 10000,
-            }
-            try:
-                cat_resp = await self.database.database.search(
-                    index=self.database.catalog_table, body=cat_query
-                )
-                hits = cat_resp.get("hits", {}).get("hits", [])
-
-                if len(hits) == 10000:
-                    logger.warning(
-                        f"DAG traversal hit 10k result limit on catalogs for catalog {catalog_id}. "
-                        "Some descendants may be truncated."
+                        "DAG traversal hit 10k result limit. Some descendants may be truncated."
                     )
 
                 next_queue = []
                 for hit in hits:
-                    child_cat_id = hit["_source"]["id"]
-                    if child_cat_id not in visited_catalogs:
-                        visited_catalogs.add(child_cat_id)
-                        next_queue.append(child_cat_id)
+                    source = hit.get("_source", {})
+                    doc_id = source.get("id")
+                    # Differentiate between Catalog and Collection
+                    doc_type = source.get("type", "Collection")
+
+                    if doc_type == "Catalog":
+                        if doc_id not in visited_catalogs:
+                            visited_catalogs.add(doc_id)
+                            next_queue.append(doc_id)
+                    else:
+                        descendant_collections.add(doc_id)
+
                 queue = next_queue
+
             except Exception as e:
-                logger.warning(
-                    f"Error fetching sub-catalogs for catalog {catalog_id}: {e}"
+                logger.error(
+                    f"Error fetching descendants for queue {queue}: {e}", exc_info=True
                 )
                 queue = []
 
@@ -1561,15 +1554,12 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
             catalog_id, request
         )
 
-        # If no collections, return empty result
-        if not allowed_collections:
-            return ItemCollection(type="FeatureCollection", features=[], links=[])
-
         # Intersect requested collections with allowed collections
         if search_request.collections:
             intersected = list(
                 set(search_request.collections) & set(allowed_collections)
             )
+            # If the user asked for specific collections but NONE of them are in this catalog's scope
             if not intersected:
                 raise HTTPException(
                     status_code=403,
@@ -1577,7 +1567,11 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
                 )
             search_request.collections = intersected
         else:
-            # No specific collections requested, use all descendant collections
+            # If the catalog is empty (no descendant collections), return empty results immediately
+            if not allowed_collections:
+                return ItemCollection(type="FeatureCollection", features=[], links=[])
+
+            # No specific collections requested, bound it to all descendant collections
             search_request.collections = allowed_collections
 
         # Hand off to core search logic

--- a/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
+++ b/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
@@ -24,6 +24,7 @@ from stac_fastapi.core.serializers import (
     CollectionSerializer,
     ItemSerializer,
 )
+from stac_fastapi.sfeos_helpers.mappings import COLLECTIONS_INDEX
 from stac_fastapi.types.errors import NotFoundError
 from stac_fastapi.types.search import BaseSearchPostRequest
 
@@ -1485,8 +1486,8 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
         queue: List[str] = [catalog_id]
         descendant_collections: Set[str] = set()
 
-        # SFEOS uses the 'collections' index for both catalogs and collections
-        index_name = "collections"
+        # SFEOS uses the collections index for both catalogs and collections (configurable via STAC_COLLECTIONS_INDEX)
+        index_name = COLLECTIONS_INDEX
 
         while queue:
             # We can fetch both Sub-Catalogs AND Collections in a single query!
@@ -1524,7 +1525,10 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
                 logger.error(
                     f"Error fetching descendants for queue {queue}: {e}", exc_info=True
                 )
-                queue = []
+                raise HTTPException(
+                    status_code=500,
+                    detail="Failed to resolve descendant collections for catalog search.",
+                ) from e
 
         return list(descendant_collections)
 
@@ -1580,8 +1584,10 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
                 search_request=search_request, request=request, **kwargs
             )
         else:
-            # Fallback if core_client not set
-            return ItemCollection(type="FeatureCollection", features=[], links=[])
+            raise HTTPException(
+                status_code=500,
+                detail="Catalog search is not configured (missing core_client).",
+            )
 
     async def catalog_search_get(
         self,
@@ -1650,4 +1656,7 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
                 **kwargs,
             )
         else:
-            return ItemCollection(type="FeatureCollection", features=[], links=[])
+            raise HTTPException(
+                status_code=500,
+                detail="Catalog search is not configured (missing core_client).",
+            )

--- a/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
+++ b/stac_fastapi/core/stac_fastapi/core/catalogs_client.py
@@ -25,7 +25,7 @@ from stac_fastapi.core.serializers import (
     ItemSerializer,
 )
 from stac_fastapi.types.errors import NotFoundError
-from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest
+from stac_fastapi.types.search import BaseSearchPostRequest
 
 logger = logging.getLogger(__name__)
 
@@ -1487,7 +1487,15 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
                 coll_resp = await self.database.database.search(
                     index=self.database.collection_table, body=coll_query
                 )
-                for hit in coll_resp.get("hits", {}).get("hits", []):
+                hits = coll_resp.get("hits", {}).get("hits", [])
+
+                if len(hits) == 10000:
+                    logger.warning(
+                        f"DAG traversal hit 10k result limit on collections for catalog {catalog_id}. "
+                        "Some descendants may be truncated."
+                    )
+
+                for hit in hits:
                     descendant_collections.add(hit["_source"]["id"])
             except Exception as e:
                 logger.warning(
@@ -1504,8 +1512,16 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
                 cat_resp = await self.database.database.search(
                     index=self.database.catalog_table, body=cat_query
                 )
+                hits = cat_resp.get("hits", {}).get("hits", [])
+
+                if len(hits) == 10000:
+                    logger.warning(
+                        f"DAG traversal hit 10k result limit on catalogs for catalog {catalog_id}. "
+                        "Some descendants may be truncated."
+                    )
+
                 next_queue = []
-                for hit in cat_resp.get("hits", {}).get("hits", []):
+                for hit in hits:
                     child_cat_id = hit["_source"]["id"]
                     if child_cat_id not in visited_catalogs:
                         visited_catalogs.add(child_cat_id)
@@ -1567,7 +1583,7 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
         # Hand off to core search logic
         if self.core_client:
             return await self.core_client.post_search(
-                search_request=search_request, request=request
+                search_request=search_request, request=request, **kwargs
             )
         else:
             # Fallback if core_client not set
@@ -1576,6 +1592,13 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
     async def catalog_search_get(
         self,
         catalog_id: str,
+        collections: List[str] | None = None,
+        ids: List[str] | None = None,
+        bbox: List[float] | None = None,
+        intersects: str | None = None,
+        datetime: str | None = None,
+        limit: int | None = None,
+        token: str | None = None,
         request: Request | None = None,
         **kwargs,
     ) -> ItemCollection | Response:
@@ -1583,25 +1606,54 @@ class CatalogsClient(AsyncBaseCatalogsClient, AsyncCatalogsSearchClient):
 
         Args:
             catalog_id: The catalog ID to search within.
+            collections: List of collection IDs to search within.
+            ids: List of item IDs to search for.
+            bbox: Bounding box to search within.
+            intersects: GeoJSON geometry to search within.
+            datetime: Datetime range to search within.
+            limit: Maximum number of results to return.
+            token: Pagination token.
             request: FastAPI request object.
-            **kwargs: Search parameters from GET query string.
+            **kwargs: Search parameters from GET query string (contains extensions like 'filter').
 
         Returns:
             ItemCollection with matching items.
         """
-        # Build GET model from kwargs
-        search_request = BaseSearchGetRequest(**kwargs)
-        # Convert GET request to POST for internal processing
-        post_request = BaseSearchPostRequest(
-            collections=search_request.collections,
-            bbox=search_request.bbox,
-            datetime=search_request.datetime,
-            limit=search_request.limit,
-            query=search_request.query if hasattr(search_request, "query") else None,
-            filter=search_request.filter if hasattr(search_request, "filter") else None,
-            sortby=search_request.sortby if hasattr(search_request, "sortby") else None,
-            fields=search_request.fields if hasattr(search_request, "fields") else None,
+        # 1. Get all descendant collections for this catalog
+        allowed_collections = await self.get_all_descendant_collections(
+            catalog_id, request
         )
-        return await self.catalog_search_post(
-            catalog_id, post_request, request, **kwargs
-        )
+
+        if not allowed_collections:
+            return ItemCollection(type="FeatureCollection", features=[], links=[])
+
+        # 2. Intersect requested collections with allowed collections
+        if collections:
+            intersected = list(set(collections) & set(allowed_collections))
+            if not intersected:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Requested collections are outside the scope of this catalog.",
+                )
+            collections = intersected
+        else:
+            # No specific collections requested, bound it to the catalog's scope
+            collections = allowed_collections
+
+        # 3. Delegate to the core client's GET search logic natively!
+        # Base arguments are passed explicitly.
+        # Extensions (like 'filter', 'sortby', 'fields') live in **kwargs and are passed implicitly!
+        if self.core_client:
+            return await self.core_client.get_search(
+                collections=collections,
+                ids=ids,
+                bbox=bbox,
+                intersects=intersects,
+                datetime=datetime,
+                limit=limit,
+                token=token,
+                request=request,
+                **kwargs,
+            )
+        else:
+            return ItemCollection(type="FeatureCollection", features=[], links=[])

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -224,16 +224,31 @@ if ENABLE_COLLECTIONS_SEARCH_ROUTE:
     extensions.append(collections_search_endpoint_ext)
 
 
+post_request_model = create_post_request_model(search_extensions)
+
 if ENABLE_CATALOGS_ROUTE:
     try:
         from stac_fastapi_catalogs_extension import (
+            CATALOGS_SEARCH_CONFORMANCE,
             CatalogsExtension,
+            CatalogsSearchExtension,
             CatalogsTransactionExtension,
         )
 
         from stac_fastapi.core.catalogs_client import CatalogsClient
 
-        catalogs_client = CatalogsClient(database=database_logic)
+        # Create core client for search delegation
+        core_client = CoreClient(
+            database=database_logic,
+            session=session,
+            post_request_model=post_request_model,
+            landing_page_id=os.getenv("STAC_FASTAPI_LANDING_PAGE_ID", "stac-fastapi"),
+        )
+
+        catalogs_client = CatalogsClient(
+            database=database_logic,
+            core_client=core_client,
+        )
 
         catalogs_extension = CatalogsExtension(
             client=catalogs_client,
@@ -244,8 +259,15 @@ if ENABLE_CATALOGS_ROUTE:
             client=catalogs_client,
             settings=settings.model_dump(),
         )
+        catalogs_search_extension = CatalogsSearchExtension(
+            client=catalogs_client,
+            search_get_request_model=create_get_request_model(search_extensions),
+            search_post_request_model=post_request_model,
+            conformance_classes=list(CATALOGS_SEARCH_CONFORMANCE),
+        )
         extensions.append(catalogs_extension)
         extensions.append(catalogs_transaction_extension)
+        extensions.append(catalogs_search_extension)
     except ImportError as e:
         logger.warning(
             "ENABLE_CATALOGS_ROUTE is set to true, but the catalogs extension is not installed. "
@@ -255,8 +277,6 @@ if ENABLE_CATALOGS_ROUTE:
 
 
 database_logic.extensions = [type(ext).__name__ for ext in extensions]
-
-post_request_model = create_post_request_model(search_extensions)
 
 items_get_request_model = create_request_model(
     model_name="ItemCollectionUri",
@@ -316,6 +336,9 @@ app.router.lifespan_context = lifespan
 # Register custom exception handler for queued items (202 Accepted)
 app.add_exception_handler(QueuedSuccess, queued_success_handler)
 app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
+
+# Set multi-tenant privacy flag in app state
+setattr(app.state, "catalogs_hide_alternate_parents", HIDE_ALTERNATE_PARENTS)
 
 try:
     from stac_fastapi.sfeos_helpers.metrics import get_instrumentator

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -222,16 +222,31 @@ if ENABLE_COLLECTIONS_SEARCH_ROUTE:
     extensions.append(collections_search_endpoint_ext)
 
 
+post_request_model = create_post_request_model(search_extensions)
+
 if ENABLE_CATALOGS_ROUTE:
     try:
         from stac_fastapi_catalogs_extension import (
+            CATALOGS_SEARCH_CONFORMANCE,
             CatalogsExtension,
+            CatalogsSearchExtension,
             CatalogsTransactionExtension,
         )
 
         from stac_fastapi.core.catalogs_client import CatalogsClient
 
-        catalogs_client = CatalogsClient(database=database_logic)
+        # Create core client for search delegation
+        core_client = CoreClient(
+            database=database_logic,
+            session=session,
+            post_request_model=post_request_model,
+            landing_page_id=os.getenv("STAC_FASTAPI_LANDING_PAGE_ID", "stac-fastapi"),
+        )
+
+        catalogs_client = CatalogsClient(
+            database=database_logic,
+            core_client=core_client,
+        )
 
         catalogs_extension = CatalogsExtension(
             client=catalogs_client,
@@ -242,8 +257,15 @@ if ENABLE_CATALOGS_ROUTE:
             client=catalogs_client,
             settings=settings.model_dump(),
         )
+        catalogs_search_extension = CatalogsSearchExtension(
+            client=catalogs_client,
+            search_get_request_model=create_get_request_model(search_extensions),
+            search_post_request_model=post_request_model,
+            conformance_classes=list(CATALOGS_SEARCH_CONFORMANCE),
+        )
         extensions.append(catalogs_extension)
         extensions.append(catalogs_transaction_extension)
+        extensions.append(catalogs_search_extension)
     except ImportError as e:
         logger.warning(
             "ENABLE_CATALOGS_ROUTE is set to true, but the catalogs extension is not installed. "
@@ -253,8 +275,6 @@ if ENABLE_CATALOGS_ROUTE:
 
 
 database_logic.extensions = [type(ext).__name__ for ext in extensions]
-
-post_request_model = create_post_request_model(search_extensions)
 
 items_get_request_model = create_request_model(
     model_name="ItemCollectionUri",
@@ -315,6 +335,9 @@ app.router.lifespan_context = lifespan
 # Register custom exception handler for queued items (202 Accepted)
 app.add_exception_handler(QueuedSuccess, queued_success_handler)
 app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
+
+# Set multi-tenant privacy flag in app state
+setattr(app.state, "catalogs_hide_alternate_parents", HIDE_ALTERNATE_PARENTS)
 
 try:
     from stac_fastapi.sfeos_helpers.metrics import get_instrumentator

--- a/stac_fastapi/tests/conftest.py
+++ b/stac_fastapi/tests/conftest.py
@@ -413,7 +413,9 @@ def build_test_app():
 def build_test_app_with_catalogs():
     """Build a test app with catalogs extension enabled."""
     from stac_fastapi_catalogs_extension import (
+        CATALOGS_SEARCH_CONFORMANCE,
         CatalogsExtension,
+        CatalogsSearchExtension,
         CatalogsTransactionExtension,
     )
 
@@ -426,8 +428,16 @@ def build_test_app_with_catalogs():
     test_database = DatabaseLogic()
     test_settings = SearchSettings()
 
-    # Create shared catalogs client
-    catalogs_client = CatalogsClient(database=test_database)
+    # Create core client for search delegation
+    core_client = CoreClient(
+        database=test_database,
+        session=None,
+        post_request_model=test_config["search_post_request_model"],
+        landing_page_id=os.getenv("STAC_FASTAPI_LANDING_PAGE_ID", "stac-fastapi"),
+    )
+
+    # Create shared catalogs client with core_client
+    catalogs_client = CatalogsClient(database=test_database, core_client=core_client)
 
     # Add catalogs extension
     catalogs_extension = CatalogsExtension(
@@ -441,6 +451,31 @@ def build_test_app_with_catalogs():
         settings=test_settings.model_dump(),
     )
 
+    # Filter out CollectionsSearchExtension to avoid duplicate base classes
+    from stac_fastapi.core.extensions.collections_search import (
+        CollectionsSearchEndpointExtension,
+    )
+
+    filtered_extensions = [
+        ext
+        for ext in test_config["extensions"]
+        if not isinstance(ext, CollectionsSearchEndpointExtension)
+    ]
+
+    # Remove CollectionsSearchEndpointExtension from test_config["extensions"]
+    test_config["extensions"] = filtered_extensions
+
+    # Add catalogs search extension
+    # Use BaseSearchGetRequest directly to avoid duplicate base class issues
+    from stac_fastapi.types.search import BaseSearchGetRequest
+
+    catalogs_search_extension = CatalogsSearchExtension(
+        client=catalogs_client,
+        search_get_request_model=BaseSearchGetRequest,
+        search_post_request_model=test_config["search_post_request_model"],
+        conformance_classes=list(CATALOGS_SEARCH_CONFORMANCE),
+    )
+
     # Add to extensions if not already present
     if not any(isinstance(ext, CatalogsExtension) for ext in test_config["extensions"]):
         test_config["extensions"].append(catalogs_extension)
@@ -449,15 +484,13 @@ def build_test_app_with_catalogs():
         for ext in test_config["extensions"]
     ):
         test_config["extensions"].append(catalogs_transaction_extension)
+    if not any(
+        isinstance(ext, CatalogsSearchExtension) for ext in test_config["extensions"]
+    ):
+        test_config["extensions"].append(catalogs_search_extension)
 
     # Update client with new extensions
-    test_config["client"] = CoreClient(
-        database=test_database,
-        session=None,
-        extensions=test_config["extensions"],
-        post_request_model=test_config["search_post_request_model"],
-        landing_page_id=os.getenv("STAC_FASTAPI_LANDING_PAGE_ID", "stac-fastapi"),
-    )
+    test_config["client"] = core_client
 
     # Create and return the app
     api = StacApi(**test_config)

--- a/stac_fastapi/tests/extensions/test_catalogs_search.py
+++ b/stac_fastapi/tests/extensions/test_catalogs_search.py
@@ -445,26 +445,28 @@ async def test_catalog_search_with_pagination(catalogs_app_client, load_test_dat
     )
     assert search_resp1.status_code == 200
     result1 = search_resp1.json()
-    assert len(result1["features"]) <= 2
+    # With 5 items and limit=2, first page should have exactly 2 features
+    assert len(result1["features"]) == 2
 
-    # Check for next link (pagination token)
+    # Check for next link (pagination token) - should exist since we have 5 items
     next_link = next(
         (link for link in result1.get("links", []) if link.get("rel") == "next"),
         None,
     )
+    assert next_link is not None, "Next link should be present when more items exist"
 
-    if next_link:
-        # Get next page using token
-        token = (
-            next_link.get("body", {}).get("token")
-            or next_link.get("href", "").split("token=")[-1]
-        )
-        search_resp2 = await catalogs_app_client.get(
-            f"/catalogs/{parent_id}/search?limit=2&token={token}"
-        )
-        assert search_resp2.status_code == 200
-        result2 = search_resp2.json()
-        assert len(result2["features"]) <= 2
+    # Get next page using token
+    token = (
+        next_link.get("body", {}).get("token")
+        or next_link.get("href", "").split("token=")[-1]
+    )
+    search_resp2 = await catalogs_app_client.get(
+        f"/catalogs/{parent_id}/search?limit=2&token={token}"
+    )
+    assert search_resp2.status_code == 200
+    result2 = search_resp2.json()
+    # Second page should also have exactly 2 features (we have 5 total)
+    assert len(result2["features"]) == 2
 
 
 @pytest.mark.asyncio

--- a/stac_fastapi/tests/extensions/test_catalogs_search.py
+++ b/stac_fastapi/tests/extensions/test_catalogs_search.py
@@ -1,0 +1,286 @@
+"""Tests for Catalogs Search Extension functionality."""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_get_empty_catalog(catalogs_app_client, load_test_data):
+    """Test GET search on a catalog with no collections returns empty results."""
+    # Create a catalog with no collections
+    test_catalog = load_test_data("test_catalog.json")
+    catalog_id = f"empty-catalog-{uuid.uuid4()}"
+    test_catalog["id"] = catalog_id
+
+    create_resp = await catalogs_app_client.post("/catalogs", json=test_catalog)
+    assert create_resp.status_code == 201
+
+    # Search within the empty catalog
+    search_resp = await catalogs_app_client.get(f"/catalogs/{catalog_id}/search")
+    assert search_resp.status_code == 200
+
+    search_result = search_resp.json()
+    assert search_result["type"] == "FeatureCollection"
+    assert search_result["features"] == []
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_post_empty_catalog(catalogs_app_client, load_test_data):
+    """Test POST search on a catalog with no collections returns empty results."""
+    # Create a catalog with no collections
+    test_catalog = load_test_data("test_catalog.json")
+    catalog_id = f"empty-catalog-{uuid.uuid4()}"
+    test_catalog["id"] = catalog_id
+
+    create_resp = await catalogs_app_client.post("/catalogs", json=test_catalog)
+    assert create_resp.status_code == 201
+
+    # Search within the empty catalog
+    search_resp = await catalogs_app_client.post(
+        f"/catalogs/{catalog_id}/search", json={}
+    )
+    assert search_resp.status_code == 200
+
+    search_result = search_resp.json()
+    assert search_result["type"] == "FeatureCollection"
+    assert search_result["features"] == []
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_scopes_to_descendant_collections(
+    catalogs_app_client, load_test_data
+):
+    """Test that catalog search only returns items from descendant collections."""
+    # Create parent catalog
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection under parent
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create an item in the collection (use global collections endpoint)
+    test_item = load_test_data("test_item.json")
+    item_id = f"test-item-{uuid.uuid4()}"
+    test_item["id"] = item_id
+    test_item["collection"] = collection_id
+
+    item_resp = await catalogs_app_client.post(
+        f"/collections/{collection_id}/items",
+        json=test_item,
+    )
+    assert item_resp.status_code == 201
+
+    # Search within the catalog
+    search_resp = await catalogs_app_client.get(f"/catalogs/{parent_id}/search")
+    assert search_resp.status_code == 200
+
+    search_result = search_resp.json()
+    assert len(search_result["features"]) == 1
+    assert search_result["features"][0]["id"] == item_id
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_rejects_out_of_scope_collections(
+    catalogs_app_client, load_test_data
+):
+    """Test that searching for out-of-scope collections returns 403."""
+    # Create two separate catalogs
+    catalog1 = load_test_data("test_catalog.json")
+    catalog1_id = f"catalog-1-{uuid.uuid4()}"
+    catalog1["id"] = catalog1_id
+
+    resp1 = await catalogs_app_client.post("/catalogs", json=catalog1)
+    assert resp1.status_code == 201
+
+    catalog2 = load_test_data("test_catalog.json")
+    catalog2_id = f"catalog-2-{uuid.uuid4()}"
+    catalog2["id"] = catalog2_id
+
+    resp2 = await catalogs_app_client.post("/catalogs", json=catalog2)
+    assert resp2.status_code == 201
+
+    # Create collection under catalog1
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{catalog1_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Try to search for catalog1's collection from catalog2
+    search_resp = await catalogs_app_client.post(
+        f"/catalogs/{catalog2_id}/search",
+        json={"collections": [collection_id]},
+    )
+    assert search_resp.status_code == 403
+
+    error = search_resp.json()
+    assert "outside the scope" in error.get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_with_multi_level_hierarchy(
+    catalogs_app_client, load_test_data
+):
+    """Test search across multi-level catalog hierarchy."""
+    # Create root catalog
+    root_catalog = load_test_data("test_catalog.json")
+    root_id = f"root-catalog-{uuid.uuid4()}"
+    root_catalog["id"] = root_id
+
+    root_resp = await catalogs_app_client.post("/catalogs", json=root_catalog)
+    assert root_resp.status_code == 201
+
+    # Create sub-catalog under root
+    sub_catalog = load_test_data("test_catalog.json")
+    sub_id = f"sub-catalog-{uuid.uuid4()}"
+    sub_catalog["id"] = sub_id
+
+    sub_resp = await catalogs_app_client.post(
+        f"/catalogs/{root_id}/catalogs", json=sub_catalog
+    )
+    assert sub_resp.status_code == 201
+
+    # Create collection under sub-catalog
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{sub_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create item in collection (use global collections endpoint)
+    test_item = load_test_data("test_item.json")
+    item_id = f"test-item-{uuid.uuid4()}"
+    test_item["id"] = item_id
+    test_item["collection"] = collection_id
+
+    item_resp = await catalogs_app_client.post(
+        f"/collections/{collection_id}/items",
+        json=test_item,
+    )
+    assert item_resp.status_code == 201
+
+    # Search from root should find item in nested collection
+    search_resp = await catalogs_app_client.get(f"/catalogs/{root_id}/search")
+    assert search_resp.status_code == 200
+
+    search_result = search_resp.json()
+    assert len(search_result["features"]) == 1
+    assert search_result["features"][0]["id"] == item_id
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_get_with_limit(catalogs_app_client, load_test_data):
+    """Test GET search with limit parameter."""
+    # Create catalog with collection
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create multiple items (use global collections endpoint)
+    for i in range(5):
+        test_item = load_test_data("test_item.json")
+        test_item["id"] = f"test-item-{i}-{uuid.uuid4()}"
+        test_item["collection"] = collection_id
+
+        item_resp = await catalogs_app_client.post(
+            f"/collections/{collection_id}/items",
+            json=test_item,
+        )
+        assert item_resp.status_code == 201
+
+    # Search with limit
+    search_resp = await catalogs_app_client.get(f"/catalogs/{parent_id}/search?limit=2")
+    assert search_resp.status_code == 200
+
+    search_result = search_resp.json()
+    assert len(search_result["features"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_post_with_limit(catalogs_app_client, load_test_data):
+    """Test POST search with limit parameter."""
+    # Create catalog with collection
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create multiple items (use global collections endpoint)
+    for i in range(5):
+        test_item = load_test_data("test_item.json")
+        test_item["id"] = f"test-item-{i}-{uuid.uuid4()}"
+        test_item["collection"] = collection_id
+
+        item_resp = await catalogs_app_client.post(
+            f"/collections/{collection_id}/items",
+            json=test_item,
+        )
+        assert item_resp.status_code == 201
+
+    # Search with limit
+    search_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/search", json={"limit": 2}
+    )
+    assert search_resp.status_code == 200
+
+    search_result = search_resp.json()
+    assert len(search_result["features"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_nonexistent_catalog(catalogs_app_client):
+    """Test search on nonexistent catalog returns 404."""
+    search_resp = await catalogs_app_client.get("/catalogs/nonexistent-catalog/search")
+    assert search_resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_post_nonexistent_catalog(catalogs_app_client):
+    """Test POST search on nonexistent catalog returns 404."""
+    search_resp = await catalogs_app_client.post(
+        "/catalogs/nonexistent-catalog/search", json={}
+    )
+    assert search_resp.status_code == 404

--- a/stac_fastapi/tests/extensions/test_catalogs_search.py
+++ b/stac_fastapi/tests/extensions/test_catalogs_search.py
@@ -224,7 +224,8 @@ async def test_catalog_search_get_with_limit(catalogs_app_client, load_test_data
     assert search_resp.status_code == 200
 
     search_result = search_resp.json()
-    assert len(search_result["features"]) <= 2
+    # With 5 items created and limit=2, should return exactly 2 features
+    assert len(search_result["features"]) == 2
 
 
 @pytest.mark.asyncio
@@ -267,7 +268,8 @@ async def test_catalog_search_post_with_limit(catalogs_app_client, load_test_dat
     assert search_resp.status_code == 200
 
     search_result = search_resp.json()
-    assert len(search_result["features"]) <= 2
+    # With 5 items created and limit=2, should return exactly 2 features
+    assert len(search_result["features"]) == 2
 
 
 @pytest.mark.asyncio
@@ -555,4 +557,5 @@ async def test_catalog_search_combined_filters(catalogs_app_client, load_test_da
     assert search_resp.status_code == 200
     search_result = search_resp.json()
     assert search_result["type"] == "FeatureCollection"
-    assert len(search_result["features"]) <= 2
+    # With 3 items created and limit=2, should return exactly 2 features
+    assert len(search_result["features"]) == 2

--- a/stac_fastapi/tests/extensions/test_catalogs_search.py
+++ b/stac_fastapi/tests/extensions/test_catalogs_search.py
@@ -284,3 +284,275 @@ async def test_catalog_search_post_nonexistent_catalog(catalogs_app_client):
         "/catalogs/nonexistent-catalog/search", json={}
     )
     assert search_resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_with_spatial_intersection(
+    catalogs_app_client, load_test_data
+):
+    """Test catalog search with spatial intersection filter."""
+    # Create catalog and collection
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create multiple items with different geometries
+    for i in range(3):
+        test_item = load_test_data("test_item.json")
+        test_item["id"] = f"test-item-{i}-{uuid.uuid4()}"
+        test_item["collection"] = collection_id
+        # Vary the geometry slightly (offset coordinates by iteration)
+        if test_item.get("geometry") and test_item["geometry"].get("coordinates"):
+            coords = test_item["geometry"]["coordinates"]
+            # Handle polygon coordinates (nested list of rings)
+            if isinstance(coords[0][0], (list, tuple)):
+                # Polygon: coords[ring][point][lon/lat]
+                test_item["geometry"]["coordinates"] = [
+                    [[c[0] + (i * 0.1), c[1] + (i * 0.1)] for c in ring]
+                    for ring in coords
+                ]
+            else:
+                # Point or LineString: coords[point][lon/lat]
+                test_item["geometry"]["coordinates"] = [
+                    [c[0] + (i * 0.1), c[1] + (i * 0.1)] for c in coords
+                ]
+
+        item_resp = await catalogs_app_client.post(
+            f"/collections/{collection_id}/items",
+            json=test_item,
+        )
+        assert item_resp.status_code == 201
+
+    # Search with spatial intersection
+    search_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/search",
+        json={"intersects": {"type": "Point", "coordinates": [-105.0, 40.0]}},
+    )
+    assert search_resp.status_code == 200
+    search_result = search_resp.json()
+    assert search_result["type"] == "FeatureCollection"
+    # Verify the endpoint accepts spatial filters without crashing
+    # (actual intersection results depend on test item geometries)
+    assert "features" in search_result
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_with_datetime_filter(catalogs_app_client, load_test_data):
+    """Test catalog search with datetime range filter."""
+    # Create catalog and collection
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create items
+    for i in range(3):
+        test_item = load_test_data("test_item.json")
+        test_item["id"] = f"test-item-{i}-{uuid.uuid4()}"
+        test_item["collection"] = collection_id
+
+        item_resp = await catalogs_app_client.post(
+            f"/collections/{collection_id}/items",
+            json=test_item,
+        )
+        assert item_resp.status_code == 201
+
+    # Search with datetime filter (wide range that should include test items)
+    search_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/search",
+        json={"datetime": "2020-01-01T00:00:00Z/2025-12-31T23:59:59Z"},
+    )
+    assert search_resp.status_code == 200
+    search_result = search_resp.json()
+    assert search_result["type"] == "FeatureCollection"
+    # Should find items within datetime range (3 items created)
+    assert len(search_result["features"]) == 3
+
+    # Search with restrictive datetime filter (should exclude items)
+    search_resp_restricted = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/search",
+        json={"datetime": "2000-01-01T00:00:00Z/2010-12-31T23:59:59Z"},
+    )
+    assert search_resp_restricted.status_code == 200
+    result_restricted = search_resp_restricted.json()
+    # Should find no items in the 2000-2010 range (test items are from 2020s)
+    assert len(result_restricted["features"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_with_pagination(catalogs_app_client, load_test_data):
+    """Test catalog search with pagination using limit and token."""
+    # Create catalog and collection
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create 5 items
+    for i in range(5):
+        test_item = load_test_data("test_item.json")
+        test_item["id"] = f"test-item-{i}-{uuid.uuid4()}"
+        test_item["collection"] = collection_id
+
+        item_resp = await catalogs_app_client.post(
+            f"/collections/{collection_id}/items",
+            json=test_item,
+        )
+        assert item_resp.status_code == 201
+
+    # First page with limit=2
+    search_resp1 = await catalogs_app_client.get(
+        f"/catalogs/{parent_id}/search?limit=2"
+    )
+    assert search_resp1.status_code == 200
+    result1 = search_resp1.json()
+    assert len(result1["features"]) <= 2
+
+    # Check for next link (pagination token)
+    next_link = next(
+        (link for link in result1.get("links", []) if link.get("rel") == "next"),
+        None,
+    )
+
+    if next_link:
+        # Get next page using token
+        token = (
+            next_link.get("body", {}).get("token")
+            or next_link.get("href", "").split("token=")[-1]
+        )
+        search_resp2 = await catalogs_app_client.get(
+            f"/catalogs/{parent_id}/search?limit=2&token={token}"
+        )
+        assert search_resp2.status_code == 200
+        result2 = search_resp2.json()
+        assert len(result2["features"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_with_sortby(catalogs_app_client, load_test_data):
+    """Test catalog search with sort parameter."""
+    # Create catalog and collection
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create items
+    for i in range(3):
+        test_item = load_test_data("test_item.json")
+        test_item["id"] = f"test-item-{i}-{uuid.uuid4()}"
+        test_item["collection"] = collection_id
+
+        item_resp = await catalogs_app_client.post(
+            f"/collections/{collection_id}/items",
+            json=test_item,
+        )
+        assert item_resp.status_code == 201
+
+    # Search with sortby (sort by properties.datetime descending)
+    search_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/search",
+        json={"sortby": [{"field": "properties.datetime", "direction": "desc"}]},
+    )
+    assert search_resp.status_code == 200
+    search_result = search_resp.json()
+    assert search_result["type"] == "FeatureCollection"
+    # Should return all 3 items (sortby is a pass-through extension)
+    assert len(search_result["features"]) == 3
+
+    # Verify items have datetime properties for sorting
+    for feature in search_result["features"]:
+        assert "properties" in feature
+        assert "datetime" in feature["properties"]
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_combined_filters(catalogs_app_client, load_test_data):
+    """Test catalog search with multiple filters combined."""
+    # Create catalog and collection
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create items
+    for i in range(3):
+        test_item = load_test_data("test_item.json")
+        test_item["id"] = f"test-item-{i}-{uuid.uuid4()}"
+        test_item["collection"] = collection_id
+
+        item_resp = await catalogs_app_client.post(
+            f"/collections/{collection_id}/items",
+            json=test_item,
+        )
+        assert item_resp.status_code == 201
+
+    # Search with multiple filters: datetime + limit
+    search_resp = await catalogs_app_client.get(
+        f"/catalogs/{parent_id}/search?datetime=2020-01-01T00:00:00Z/2025-12-31T23:59:59Z&limit=2"
+    )
+    assert search_resp.status_code == 200
+    search_result = search_resp.json()
+    assert search_result["type"] == "FeatureCollection"
+    assert len(search_result["features"]) <= 2

--- a/stac_fastapi/tests/extensions/test_catalogs_search.py
+++ b/stac_fastapi/tests/extensions/test_catalogs_search.py
@@ -561,3 +561,49 @@ async def test_catalog_search_combined_filters(catalogs_app_client, load_test_da
     assert search_result["type"] == "FeatureCollection"
     # With 3 items created and limit=2, should return exactly 2 features
     assert len(search_result["features"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_with_invalid_collection_id(
+    catalogs_app_client, load_test_data
+):
+    """Test catalog search with invalid collection ID in request."""
+    # Create catalog and collection
+    parent_catalog = load_test_data("test_catalog.json")
+    parent_id = f"parent-catalog-{uuid.uuid4()}"
+    parent_catalog["id"] = parent_id
+
+    parent_resp = await catalogs_app_client.post("/catalogs", json=parent_catalog)
+    assert parent_resp.status_code == 201
+
+    # Create collection
+    test_collection = load_test_data("test_collection.json")
+    collection_id = f"test-collection-{uuid.uuid4()}"
+    test_collection["id"] = collection_id
+
+    coll_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/collections", json=test_collection
+    )
+    assert coll_resp.status_code == 201
+
+    # Create items
+    for i in range(2):
+        test_item = load_test_data("test_item.json")
+        test_item["id"] = f"test-item-{i}-{uuid.uuid4()}"
+        test_item["collection"] = collection_id
+
+        item_resp = await catalogs_app_client.post(
+            f"/collections/{collection_id}/items",
+            json=test_item,
+        )
+        assert item_resp.status_code == 201
+
+    # Search requesting a collection that doesn't exist in this catalog
+    search_resp = await catalogs_app_client.post(
+        f"/catalogs/{parent_id}/search",
+        json={"collections": ["nonexistent-collection"]},
+    )
+    # Should return 403 because requested collection is outside catalog scope
+    assert search_resp.status_code == 403
+    error_resp = search_resp.json()
+    assert "outside the scope" in error_resp.get("detail", "").lower()


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**

- Added `CatalogsSearchExtension` support to enable scoped search within catalogs and their descendants. Catalog search uses BFS DAG traversal to discover all descendant collections and enforces scope with 403 Forbidden when users request out-of-scope collections. Supports all search parameters (datetime, intersects, sortby, limit, token) via pass-through to core search logic. [#782](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/782)

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog