### PR TITLE
fix: stop double URL-decoding CQL2 filter on GET endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed CQL2 `LIKE` filters silently returning no results on `GET /search`, `GET /aggregate`, and `GET /collections` when the search term began with a valid percent-escape (e.g. `%banks%`, `%data%`). Query parameters are already URL-decoded by Starlette, so the extra `unquote_plus` was double-decoding the filter and corrupting those terms; the decoded value is now parsed directly. [#783](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/783)
+
 ### Removed
 
 ### Updated

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -418,15 +418,17 @@ class CoreClient(AsyncBaseCoreClient):
                         parsed_filter = filter_expr
                     elif filter_lang == "cql2-text" or filter_lang is None:
                         # For cql2-text or when no filter_lang is specified, try both formats
+                        # Query params are already percent-decoded by Starlette;
+                        # decoding again corrupts CQL2 LIKE patterns like "%banks%"
+                        # ("%ba" is a valid escape).
                         try:
                             # First try to parse as JSON
-                            parsed_filter = orjson.loads(unquote_plus(filter_expr))
+                            parsed_filter = orjson.loads(filter_expr)
                         except Exception:
                             # If that fails, use pygeofilter to convert CQL2-text to CQL2-JSON
                             try:
                                 # Parse CQL2-text and convert to CQL2-JSON
-                                text_filter = unquote_plus(filter_expr)
-                                parsed_ast = parse_cql2_text(text_filter)
+                                parsed_ast = parse_cql2_text(filter_expr)
                                 parsed_filter = to_cql2(parsed_ast)
                             except Exception as e:
                                 # If parsing fails, provide a helpful error message
@@ -435,8 +437,8 @@ class CoreClient(AsyncBaseCoreClient):
                                     detail=f"Invalid CQL2-text filter: {e}. Please check your syntax.",
                                 )
                     else:
-                        # For explicit cql2-json, parse as JSON
-                        parsed_filter = orjson.loads(unquote_plus(filter_expr))
+                        # Explicit cql2-json: already percent-decoded (see note above).
+                        parsed_filter = orjson.loads(filter_expr)
                 except Exception as e:
                     # Catch any other parsing errors
                     raise HTTPException(
@@ -768,8 +770,10 @@ class CoreClient(AsyncBaseCoreClient):
 
         if filter_expr:
             base_args["filter_lang"] = "cql2-json"
+            # Already percent-decoded by Starlette; decoding again would corrupt
+            # CQL2 LIKE patterns like "%banks%" ("%ba" is a valid escape).
             base_args["filter"] = orjson.loads(
-                unquote_plus(filter_expr)
+                filter_expr
                 if filter_lang == "cql2-json"
                 else to_cql2(parse_cql2_text(filter_expr))
             )

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/aggregation/client.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/aggregation/client.py
@@ -214,7 +214,9 @@ class EsAsyncBaseAggregationClient(AsyncBaseAggregationClient):
             return orjson.loads(to_cql2(parse_cql2_text(filter)))
         elif filter_lang == "cql2-json":
             if isinstance(filter, str):
-                return orjson.loads(unquote_plus(filter))
+                # Already percent-decoded by Starlette; decoding again would corrupt
+                # CQL2 LIKE patterns like "%banks%" ("%ba" is a valid escape).
+                return orjson.loads(filter)
             else:
                 return filter
         else:

--- a/stac_fastapi/tests/extensions/test_filter.py
+++ b/stac_fastapi/tests/extensions/test_filter.py
@@ -1862,3 +1862,108 @@ async def test_queryables_excluded_fields(
     # Clean up
     r = await app_client.delete(f"/collections/{collection_id}")
     r.raise_for_status()
+
+
+# LIKE terms whose first two characters form a valid percent-escape, so a
+# double URL-decode corrupted them ("%banks%" -> "%ba" -> byte 0xBA). Terms
+# like "garden"/"ocean" were unaffected, which made the bug look term-dependent.
+HEX_PREFIX_LIKE_TERMS = ["banks", "bank", "data", "beach", "feed"]
+
+
+@pytest.mark.asyncio
+async def test_get_search_cql2_like_not_double_url_decoded(app_client, ctx):
+    """GET /search must not re-percent-decode the ``filter`` query parameter.
+
+    Starlette already decodes query params once; a second decode corrupted
+    LIKE terms with a hex-pair prefix, so GET returned 0 hits while POST (dict
+    body) worked. Asserts GET agrees with POST on first page and numberMatched.
+    """
+    collection_id = ctx.item["collection"]
+    item = copy.deepcopy(ctx.item)
+    item["id"] = "banks-bank-data-beach-feed"
+    resp = await app_client.post(f"/collections/{collection_id}/items", json=item)
+    assert resp.status_code == 201
+
+    for term in HEX_PREFIX_LIKE_TERMS:
+        cql2 = {"op": "like", "args": [{"property": "id"}, f"%{term}%"]}
+        get_resp = await app_client.get(
+            "/search",
+            params={"filter-lang": "cql2-json", "filter": json.dumps(cql2)},
+        )
+        post_resp = await app_client.post(
+            "/search", json={"filter-lang": "cql2-json", "filter": cql2}
+        )
+        assert get_resp.status_code == 200, term
+        get_json, post_json = get_resp.json(), post_resp.json()
+        get_ids = {f["id"] for f in get_json["features"]}
+        post_ids = {f["id"] for f in post_json["features"]}
+
+        assert item["id"] in get_ids, f"GET /search dropped LIKE %{term}%"
+        assert get_ids == post_ids, f"GET vs POST first page diverged for %{term}%"
+        assert (
+            get_json["numberMatched"] == post_json["numberMatched"]
+        ), f"GET vs POST count diverged for %{term}%"
+
+    # Multi-condition AND filter (the shape originally blamed in issue #368),
+    # combining several hex-prefixed terms in a single GET request.
+    multi = {
+        "op": "and",
+        "args": [
+            {"op": "like", "args": [{"property": "id"}, "%banks%"]},
+            {"op": "like", "args": [{"property": "id"}, "%data%"]},
+            {"op": "like", "args": [{"property": "id"}, "%beach%"]},
+        ],
+    }
+    get_resp = await app_client.get(
+        "/search", params={"filter-lang": "cql2-json", "filter": json.dumps(multi)}
+    )
+    post_resp = await app_client.post(
+        "/search", json={"filter-lang": "cql2-json", "filter": multi}
+    )
+    assert get_resp.status_code == 200
+    assert {f["id"] for f in get_resp.json()["features"]} == {item["id"]}
+    assert get_resp.json()["numberMatched"] == post_resp.json()["numberMatched"]
+
+
+@pytest.mark.asyncio
+async def test_get_aggregate_cql2_like_not_double_url_decoded(app_client, ctx):
+    """GET /aggregate must agree with POST /aggregate for hex-prefixed LIKE terms.
+
+    The aggregation client had the same double-decode on a str ``filter``, so
+    GET /aggregate undercounted the same terms GET /search dropped.
+    """
+    collection_id = ctx.item["collection"]
+    item = copy.deepcopy(ctx.item)
+    item["id"] = "banks-bank-data-beach-feed"
+    resp = await app_client.post(f"/collections/{collection_id}/items", json=item)
+    assert resp.status_code == 201
+
+    def total_count(payload):
+        for agg in payload["aggregations"]:
+            if agg["name"] == "total_count":
+                return agg["value"]
+        return None
+
+    for term in HEX_PREFIX_LIKE_TERMS:
+        cql2 = {"op": "like", "args": [{"property": "id"}, f"%{term}%"]}
+        get_resp = await app_client.get(
+            "/aggregate",
+            params={
+                "aggregations": "total_count",
+                "filter-lang": "cql2-json",
+                "filter": json.dumps(cql2),
+            },
+        )
+        post_resp = await app_client.post(
+            "/aggregate",
+            json={
+                "aggregations": ["total_count"],
+                "filter-lang": "cql2-json",
+                "filter": cql2,
+            },
+        )
+        assert get_resp.status_code == 200, term
+        get_total = total_count(get_resp.json())
+        post_total = total_count(post_resp.json())
+        assert get_total == post_total, f"GET vs POST /aggregate diverged for %{term}%"
+        assert get_total >= 1, f"GET /aggregate missed item for %{term}%"


### PR DESCRIPTION
**Related Issue(s):**

- None filed upstream; full reproduction and root cause below.

**Description:**

`GET /search`, `GET /aggregate`, and `GET /collections` run `unquote_plus` on the `filter` query parameter, which FastAPI/Starlette has **already URL-decoded**. The second decode corrupts CQL2 `LIKE` patterns whose term begins with a valid percent-escape — e.g. `%banks%` → `%ba` → byte `0xBA` — so those requests silently return **0 results**, while the equivalent `POST` request (filter arrives as a dict, never re-decoded) returns the correct hits.

The failure is term-dependent in a way that looks baffling at first: only terms whose first two characters form a valid hex pair break (`bank`, `banks`, `data`, `beach`, `face`, …); `garden`, `ocean`, `water`, … are unaffected because `ga`/`oc`/`wa` aren't valid escapes.

**Root cause:** query parameters are URL-decoded exactly once by the framework, so the extra `unquote_plus` is a redundant second decode — a no-op on most filters, but lossy for any value containing `%`. (It came in with #269 while aligning GET filter handling with the broader stac-fastapi/pgstac code, and was duplicated into the aggregation client in #376.)

**Fix:** parse the already-decoded value directly. Sites:
- `stac_fastapi/core/.../core.py` — `get_search` (GET `/search`, also `/collections/{id}/items`) and `all_collections` (GET `/collections`)
- `stac_fastapi/sfeos_helpers/.../aggregation/client.py` — `get_filter` (GET `/aggregate`)

**Reproduction (before this change):**

```
GET  /search?filter-lang=cql2-json&filter={"op":"like","args":[{"property":"description"},"%banks%"]}
  -> numberMatched: 0
POST /search {"filter-lang":"cql2-json","filter":{"op":"like","args":[{"property":"description"},"%banks%"]}}
  -> numberMatched: 127
```

Emitted ES query on the GET path: `{"wildcard": {"description": {"value": "<0xBA>nks*", "case_insensitive": true}}}` — the leading `%ba` was consumed into byte `0xBA`, so it matches nothing.

**Possibly also affected:** this `unquote_plus(filter)` idiom came from the shared stac-fastapi lineage, so `stac-fastapi` core and `stac-fastapi-pgstac` may carry the same double-decode on their GET filter handling — worth a check.

**PR Checklist:**

- [x] Code is formatted and linted (`pre-commit run --all-files`)
- [x] Regression tests added (`extensions/test_filter.py`): GET vs POST agreement on first page + counts for affected LIKE terms, plus a multi-condition AND, on `/search` and `/aggregate`. Pass locally; relying on CI for the full matrix.
- [ ] Documentation has been updated to reflect changes, if applicable (N/A)
- [x] Changes are added to the changelog
