### PR TITLE
helm: add helm values extraContainers, envFrom and extraEnv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Added `app.extraContainers` to allow injecting additional sidecar containers into the Deployment.
+- Added `app.envFrom` to allow configuring container `envFrom` sources.
+- Added `app.extraEnv` to allow adding additional container environment entries.
+
 ### Added
 
 ### Changed

--- a/helm-chart/stac-fastapi/templates/_helpers.tpl
+++ b/helm-chart/stac-fastapi/templates/_helpers.tpl
@@ -231,6 +231,7 @@ Create environment variables for the application
 {{- define "stac-fastapi.environment" -}}
 {{- $env := default (dict) .Values.app.env -}}
 {{- $envFromSecret := default (dict) .Values.app.envFromSecret -}}
+{{- $extraEnv := default (dict) .Values.app.extraEnv -}}
 {{- $dbAuth := deepCopy (default (dict) .Values.app.databaseAuth) -}}
 {{- $opensearchSecurity := default (dict) .Values.opensearchSecurity -}}
 {{- $redisConfig := default (dict) .Values.redis -}}
@@ -306,6 +307,9 @@ Create environment variables for the application
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ $key }}
+{{- end }}
+{{- range $i, $val := $extraEnv }}
+- {{ $val | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/helm-chart/stac-fastapi/templates/deployment.yaml
+++ b/helm-chart/stac-fastapi/templates/deployment.yaml
@@ -76,12 +76,21 @@ spec:
             {{- toYaml .Values.app.readinessProbe | nindent 12 }}
           env:
             {{- include "stac-fastapi.environment" . | nindent 12 }}
+          {{- with .Values.app.envFrom }}
+          envFrom:
+            {{- range $i, $val := . }}
+              - {{ $val | toYaml | nindent 16 }}
+            {{ end -}}
+          {{- end }}
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
           {{- with .Values.app.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- with .Values.app.extraContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.app.extraVolumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/stac-fastapi/templates/deployment.yaml
+++ b/helm-chart/stac-fastapi/templates/deployment.yaml
@@ -78,9 +78,7 @@ spec:
             {{- include "stac-fastapi.environment" . | nindent 12 }}
           {{- with .Values.app.envFrom }}
           envFrom:
-            {{- range $i, $val := . }}
-              - {{ $val | toYaml | nindent 16 }}
-            {{ end -}}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}

--- a/helm-chart/stac-fastapi/values.yaml
+++ b/helm-chart/stac-fastapi/values.yaml
@@ -178,9 +178,18 @@ app:
   extraVolumeMounts: []
   extraVolumes: []
 
+  # Additional containers to add to deployment
+  extraContainers: []
+
   # Additional environment variables from secrets
   envFromSecret: {}
     # ES_API_KEY: "es-api-key-secret"
+
+  # Extra environment variable
+  extraEnv: []
+
+  # Load environment variables using envFrom
+  envFrom: []
 
   # Database authentication configuration for bundled backends
   databaseAuth:


### PR DESCRIPTION
**Description:**

* Add `app.extraContainers` to allow the creation of extra containers. This may be needed to allow the use of sidecar pattern.
* Add `app.extraEnv` to allow to set extra environment variables
* Add `app.envFrom` to allow the use of envFrom. This may be usefull to load environment variables from a configmap

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog